### PR TITLE
Fix sourcemaps for JS files that are modified by ember-scoped-css

### DIFF
--- a/ember-scoped-css/src/addon-hbs-rollup.js
+++ b/ember-scoped-css/src/addon-hbs-rollup.js
@@ -34,7 +34,11 @@ export default function rollupCssColocation() {
             return rewriteHbs(hbs, classes, tags, postfix);
           });
 
-          return rewrittenHbsJs;
+          return {
+            code: rewrittenHbsJs,
+            // this rollup plugin changes only the template string, so the code structure is the same
+            map: null,
+          };
         }
       }
     },

--- a/ember-scoped-css/src/addon-js-unplugin.js
+++ b/ember-scoped-css/src/addon-js-unplugin.js
@@ -31,11 +31,16 @@ export default createUnplugin(() => {
           css = result.css;
           code = recast.print(result.ast).code;
           this.getModuleInfo(jsPath).meta.gjsCss = result.css;
+
+          // TODO: generate changed source map. Implementation depends on implemented rollup plugin for style tag
         }
       }
 
       if (!css) {
-        return code;
+        return {
+          code,
+          map: null,
+        };
       }
 
       // add css import for js and gjs files
@@ -44,12 +49,17 @@ export default createUnplugin(() => {
       // rewrite hbs in js in case it is gjs file (for gjs files hbs is already in js file)
       // for js components "@embroider/addon-dev/template-colocation-plugin", will add hbs to js later. So there is hbs plugin to rewrite hbs
 
-      return replaceHbsInJs(code, (hbs) => {
+      const rewrittenCode = replaceHbsInJs(code, (hbs) => {
         const { classes, tags } = getClassesTagsFromCss(css);
         const postfix = getPostfix(cssPath);
         const rewritten = rewriteHbs(hbs, classes, tags, postfix);
         return rewritten;
       });
+
+      return {
+        code: rewrittenCode,
+        map: null,
+      };
     },
   };
 });


### PR DESCRIPTION
This PRs fixes source maps for components with co-located css files. In this case, only the template string is rewritten, so the code structure stays the same. This is why we can return map: null from the transform method.

> Note:
Source maps for gjs and gts components with style tags are broken. It can be fixed only after the rollup for style tags will be implemented.