### PR TITLE
Fix package, publish dist

### DIFF
--- a/.changeset/tender-apples-swim.md
+++ b/.changeset/tender-apples-swim.md
@@ -1,0 +1,5 @@
+---
+'ember-scoped-css': patch
+---
+
+Publish 'dist' as well as 'src', as 'dist' contains the cjs variants of the build tools

--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -10,6 +10,7 @@
   "type": "module",
   "files": [
     "src",
+    "dist",
     "addon-main.cjs"
   ],
   "exports": {


### PR DESCRIPTION
`dist` wasn't published, but we need it published for not-yet-ESM node-land