### PR TITLE
Change license of scoped-css to MIT, which matches all the other packages

### DIFF
--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -5,7 +5,7 @@
   "keywords": [
     "ember-addon"
   ],
-  "license": "ISC",
+  "license": "MIT",
   "author": "",
   "type": "module",
   "files": [


### PR DESCRIPTION
In this repo, scoped-css was the only package not using MIT -- ISC is similar, and there is barely a difference -- but.. _for consistency_