### PR TITLE
Fix the live reload behavior of classic ember apps when editing the CSS for a corresponding gjs and gts file

### DIFF
--- a/.changeset/purple-ducks-cry.md
+++ b/.changeset/purple-ducks-cry.md
@@ -1,0 +1,5 @@
+---
+'ember-scoped-css': patch
+---
+
+Fix the live reload behavior of classic ember apps when editing the CSS for a corresponding gjs and gts file

--- a/ember-scoped-css/src/lib/scoped-css-preprocessor.js
+++ b/ember-scoped-css/src/lib/scoped-css-preprocessor.js
@@ -150,7 +150,7 @@ class ScopedFilter extends Filter {
             for (let template of templates) {
               templateComparison.push(
                 didTemplateChange(
-                  template.contents,
+                  template,
                   previousClasses,
                   classes,
                   tags,


### PR DESCRIPTION
Previously, when saving a CSS, you'd get this error:
```
Build Error (ScopedFilter) in classic-app/components/show-time.css

Cannot set properties of undefined (setting 'loc')
```
