### PR TITLE
Add better error when `scoped-class` makes it way to runtime

### DIFF
--- a/ember-scoped-css/classic-app-support/helpers/scoped-class.js
+++ b/ember-scoped-css/classic-app-support/helpers/scoped-class.js
@@ -1,0 +1,1 @@
+export { scopedClass as default } from 'ember-scoped-css';

--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "type": "module",
   "files": [
+    "classic-app-support",
     "src",
     "dist",
     "declarations",
@@ -106,7 +107,10 @@
   "ember-addon": {
     "main": "addon-main.cjs",
     "type": "addon",
-    "version": 2
+    "version": 2,
+    "app-js": {
+      "./helpers/scoped-class.js": "./classic-app-support/helpers/scoped-class.js"
+    }
   },
   "engines": {
     "node": ">= 18"

--- a/ember-scoped-css/src/runtime/index.ts
+++ b/ember-scoped-css/src/runtime/index.ts
@@ -6,6 +6,6 @@
  */
 export function scopedClass(className: string): string {
   throw new Error(
-    `scopedClass is not available at runtime. Cannot do anything with ${className}`,
+    `scopedClass is not available at runtime. Cannot do anything with ${className}. If you see this message, there could be two reasons: 1) No CSS file associated with this component, or 2) The build transforms are not installed.`,
   );
 }

--- a/test-apps/classic-app/app/components/in-app/misuse/no-css.hbs
+++ b/test-apps/classic-app/app/components/in-app/misuse/no-css.hbs
@@ -1,0 +1,1 @@
+<p class={{scoped-class "foo"}}>No CSS here!</p>

--- a/test-apps/classic-app/tests/integration/components/in-app/misuse-test.js
+++ b/test-apps/classic-app/tests/integration/components/in-app/misuse-test.js
@@ -1,0 +1,15 @@
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+import { module, skip } from 'qunit';
+
+import { setupRenderingTest } from 'classic-app/tests/helpers';
+
+module('[In App] Misuse', function (hooks) {
+  setupRenderingTest(hooks);
+
+  skip('it has scoped class', async function () {
+    // Errors (intentional, but we can't catch it)
+    // https://github.com/qunitjs/qunit/issues/1736
+    await render(hbs`<InApp::Misuse::NoCss />`);
+  });
+});


### PR DESCRIPTION
Resolves #218 

This is 100% unintentional-by-the-dev behavior -- this PR improves guidance for the dev when this scenario happens