### PR TITLE
Remove find-up

### DIFF
--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -81,7 +81,6 @@
     "ember-cli-babel": "^8.2.0",
     "ember-source": "^5.9.0",
     "ember-template-recast": "^6.1.3",
-    "find-up": "^5.0.0",
     "glob": "^8.1.0",
     "postcss": "^8.4.38",
     "postcss-selector-parser": "^6.0.16",

--- a/ember-scoped-css/pnpm-lock.yaml
+++ b/ember-scoped-css/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       ember-template-recast:
         specifier: ^6.1.3
         version: 6.1.4
-      find-up:
-        specifier: ^5.0.0
-        version: 5.0.0
       glob:
         specifier: ^8.1.0
         version: 8.1.0

--- a/ember-scoped-css/src/lib/path/utils.findWorkspacePath.test.ts
+++ b/ember-scoped-css/src/lib/path/utils.findWorkspacePath.test.ts
@@ -1,0 +1,57 @@
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { findWorkspacePath } from './utils.js';
+import { paths } from './utils.paths.test.js';
+
+describe('findWorkspacePath()', () => {
+  it('from a component', () => {
+    let file = path.join(paths.embroiderApp, 'app/components/forth.gjs');
+    let result = findWorkspacePath(file, { cwd: paths.embroiderApp });
+
+    expect(result).toBe(paths.embroiderApp);
+  });
+
+  it('from a component with app in the name', () => {
+    let file = path.join(paths.embroiderApp, 'app/components/page/app.gjs');
+    let result = findWorkspacePath(file, { cwd: paths.embroiderApp });
+
+    expect(result).toBe(paths.embroiderApp);
+  });
+
+  it('from a component with app in the path', () => {
+    let file = path.join(
+      paths.embroiderApp,
+      'app/components/app/page/forth.gjs',
+    );
+    let result = findWorkspacePath(file, { cwd: paths.embroiderApp });
+
+    expect(result).toBe(paths.embroiderApp);
+  });
+
+  it('from an unrelated path', () => {
+    let file = path.join(
+      paths.embroiderApp,
+      'app/components/app/page/forth.gjs',
+    );
+    let result = findWorkspacePath(file, { cwd: paths.classicApp });
+
+    expect(result).toBe(paths.embroiderApp);
+  });
+
+  it('from an unrelated CWD', () => {
+    let file = path.join(paths.classicApp, 'app/components/app/page/forth.gjs');
+    let result = findWorkspacePath(file, { cwd: paths.embroiderApp });
+
+    expect(result).toBe(paths.classicApp);
+  });
+
+  it('from outside the CWD entirely', () => {
+    expect(() => {
+      let file = path.join('/tmp/app/components/app/page/forth.gjs');
+
+      findWorkspacePath(file, { cwd: paths.classicApp });
+    }).toThrowError(/Could not determine project/);
+  });
+});


### PR DESCRIPTION
find-up has created a problem internally, where we get a node (C++) error, due to "something" going poorly when debugging.

In order to debug, I've re-implemented _what we need_ from find-up, which doesn't appear to have a performance impact.