### PR TITLE
Remove log that was added to help debug mis-transformed-files, but it…

### DIFF
--- a/ember-scoped-css/src/lib/path/template-transform-paths.js
+++ b/ember-scoped-css/src/lib/path/template-transform-paths.js
@@ -88,8 +88,6 @@ export function fixFilename(filename) {
     return fileName;
   }
 
-  console.debug(`[ScopedCSS]: Failed to handle ${fileName}`);
-
   // Fallback to what the plugin system gives us.
   // This may be wrong, and if wrong, reveals
   // unhandled scenarios with the file names in the plugin infra


### PR DESCRIPTION
… turns out that sometimes files are correct in the template transform, and don't *need* to be altered, making the message incorrect