### PR TITLE
Hit the file system 3 less times per template-using file (hbs, gjs, gts)

### DIFF
--- a/ember-scoped-css/src/lib/path/template-transform-paths.js
+++ b/ember-scoped-css/src/lib/path/template-transform-paths.js
@@ -36,7 +36,7 @@ export function fixFilename(filename) {
    * - the filename looks like an absolute path, but swapped out the 'app' part of the path
    *   with the module name, so the file paths never exist on disk
    */
-  if (!fileName.includes('/app/')) {
+  if (!fileName.includes('/app/') && !fileName.includes('/node_modules/.embroider/')) {
     let maybeModule = fileName.replace(workspace, '');
     let [maybeScope, ...rest] = maybeModule.split('/').filter(Boolean);
     let parts = rest;
@@ -57,11 +57,7 @@ export function fixFilename(filename) {
      */
     let candidatePath = path.join(workspace, 'app', relative);
 
-    let resolved = findCandidate(candidatePath);
-
-    if (resolved) {
-      return resolved;
-    }
+    return candidatePath;
   }
 
   /**
@@ -76,11 +72,7 @@ export function fixFilename(filename) {
       '/app/',
     );
 
-    let resolved = findCandidate(candidatePath);
-
-    if (resolved) {
-      return resolved;
-    }
+    return candidatePath;
   }
 
   // TODO: why are we passed files to other projects?
@@ -92,24 +84,4 @@ export function fixFilename(filename) {
   // This may be wrong, and if wrong, reveals
   // unhandled scenarios with the file names in the plugin infra
   return fileName;
-}
-
-const COMPILES_TO_JS = ['.hbs', '.gjs', '.gts'];
-
-function findCandidate(filePath) {
-  if (existsSync(filePath)) {
-    return filePath;
-  }
-
-  let withoutExt = withoutExtension(filePath);
-
-  for (let ext of COMPILES_TO_JS) {
-    let candidatePath = withoutExt + ext;
-
-    if (existsSync(candidatePath)) {
-      return candidatePath;
-    }
-  }
-
-  return null;
 }

--- a/ember-scoped-css/src/lib/path/template-transform-paths.js
+++ b/ember-scoped-css/src/lib/path/template-transform-paths.js
@@ -1,8 +1,6 @@
 import path from 'node:path';
 
-import { existsSync } from 'fs';
-
-import { findWorkspacePath, withoutExtension } from './utils';
+import { findWorkspacePath } from './utils';
 
 /**
  * template plugins do not hand us the correct file path.
@@ -36,7 +34,10 @@ export function fixFilename(filename) {
    * - the filename looks like an absolute path, but swapped out the 'app' part of the path
    *   with the module name, so the file paths never exist on disk
    */
-  if (!fileName.includes('/app/') && !fileName.includes('/node_modules/.embroider/')) {
+  if (
+    !fileName.includes('/app/') &&
+    !fileName.includes('/node_modules/.embroider/')
+  ) {
     let maybeModule = fileName.replace(workspace, '');
     let [maybeScope, ...rest] = maybeModule.split('/').filter(Boolean);
     let parts = rest;

--- a/ember-scoped-css/src/lib/path/template-transform-paths.test.ts
+++ b/ember-scoped-css/src/lib/path/template-transform-paths.test.ts
@@ -45,6 +45,19 @@ describe('fixFilename()', () => {
     );
   });
 
+  it('is not confused with "app" in the embroider rewritten location', () => {
+    let file = path.join(
+      paths.embroiderApp,
+      paths.rewritten,
+      'components/app/page/template-only.hbs',
+    );
+    let corrected = fixFilename(file);
+
+    expect(corrected).to.equal(
+      path.join(paths.embroiderApp, 'app/components/app/page/template-only.hbs'),
+    );
+  });
+
   it('works with classic paths (w/ module name)', () => {
     let file = path.join(
       paths.classicApp,

--- a/ember-scoped-css/src/lib/path/template-transform-paths.test.ts
+++ b/ember-scoped-css/src/lib/path/template-transform-paths.test.ts
@@ -54,7 +54,10 @@ describe('fixFilename()', () => {
     let corrected = fixFilename(file);
 
     expect(corrected).to.equal(
-      path.join(paths.embroiderApp, 'app/components/app/page/template-only.hbs'),
+      path.join(
+        paths.embroiderApp,
+        'app/components/app/page/template-only.hbs',
+      ),
     );
   });
 


### PR DESCRIPTION
Previously, we'd try to resolve the real file when fixing the template-transform paths. 

It turns out that we don't need that precise of information, so we can get away with not hitting the FS at all during this phase.