### PR TITLE
Add more gts tests

### DIFF
--- a/test-apps/classic-app/app/components/in-app/basic.css
+++ b/test-apps/classic-app/app/components/in-app/basic.css
@@ -1,0 +1,7 @@
+.has-a-style {
+  color: rgb(0,100,50);
+}
+
+div {
+  font-weight: bold;
+}

--- a/test-apps/classic-app/app/components/in-app/basic.css
+++ b/test-apps/classic-app/app/components/in-app/basic.css
@@ -1,5 +1,5 @@
 .has-a-style {
-  color: rgb(0,100,50);
+  color: rgb(0, 100, 50);
 }
 
 div {

--- a/test-apps/classic-app/app/components/in-app/basic.gts
+++ b/test-apps/classic-app/app/components/in-app/basic.gts
@@ -1,0 +1,3 @@
+<template>
+  <div class="has-a-style">text here</div>
+</template>

--- a/test-apps/classic-app/tests/shared-scenarios/in-app/basic-test.gts
+++ b/test-apps/classic-app/tests/shared-scenarios/in-app/basic-test.gts
@@ -18,6 +18,6 @@ module('[In App] basic', function(hooks) {
 
     assert.dom('div').hasClass('has-a-style_e8d85123f');
     assert.dom('div').hasClass(scopedClass('has-a-style', 'classic-app/components/in-app/basic'));
-    assert.dom('div').hasStyle({ color: 'rgb(0, 100, 50)', fontWeight: 'bold' });
+    assert.dom('div').hasStyle({ color: 'rgb(0, 100, 50)', fontWeight: '700' });
   });
 });

--- a/test-apps/classic-app/tests/shared-scenarios/in-app/basic-test.gts
+++ b/test-apps/classic-app/tests/shared-scenarios/in-app/basic-test.gts
@@ -1,0 +1,23 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import Basic from 'classic-app/components/in-app/basic';
+
+import { scopedClass } from 'ember-scoped-css/test-support';
+
+module('[In App] basic', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('has a style on an element', async function(assert) {
+    await render(
+      <template>
+        <Basic />
+      </template>
+    );
+
+    assert.dom('div').hasClass('has-a-style_e8d85123f');
+    assert.dom('div').hasClass(scopedClass('has-a-style', 'classic-app/components/in-app/basic'));
+    assert.dom('div').hasStyle({ color: 'rgb(0, 100, 50)', fontWeight: 'bold' });
+  });
+});


### PR DESCRIPTION
While we have some gts usage in the tests, we don't have basic tests ensuring the base  functionality works with gts.

This is related to: https://github.com/soxhub/ember-scoped-css/issues/250


Our coverage is a bit wonky to track, because we actually need to follow up with:
- https://github.com/soxhub/ember-scoped-css/issues/176
which allows us to symlink all the same components and tests between the different environments. This won't happen in this PR, but will be good for a follow up.