### PR TITLE
add support for interop with other pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ const app = new EmberApp(defaults, {
   'ember-scoped-css': {
     layerName: 'app-styles', // default: 'components', set to false to disable the layer
     additionalRoots: ['routes/'], // default: [], set this to use scoped-css in pods-using apps
+    passthrough: ['some-other-file.css'], // default: [] this is only used in a non-embroider app to pass files through the build pipeline
+    passthroughDestination: 'assets' // default: undefined this alters where the passthrough files are placed in the output tree
   }
 });
 ```

--- a/ember-scoped-css/src/build/ember-classic-support.js
+++ b/ember-scoped-css/src/build/ember-classic-support.js
@@ -272,7 +272,7 @@ export default class ScopedCssPreprocessor {
       appCss,
       mergedOtherTrees,
       componentStyles,
-    ]);
+    ], {overwrite: true});
 
     let newOutput = new Concat(mergedStyles, {
       outputFile: options.outputPaths['app'],
@@ -280,6 +280,14 @@ export default class ScopedCssPreprocessor {
       sourceMapConfig: { enabled: true },
     });
 
-    return newOutput;
+    if (this.userOptions?.passthrough) {
+      let passedThrough = new Funnel(mergedStyles, {
+        include: this.userOptions.passthrough,
+        destDir: this.userOptions.passthroughDestination,
+      });
+      return new MergeTrees([passedThrough, newOutput], { overwrite: true });
+    } else {
+      return newOutput;
+    }
   }
 }


### PR DESCRIPTION
This should allow us to interop better with other css pipelines (such as ember-css-modules wile people are migrating). In my testing I am able to pass the following config to the ember app: 

```js
    cssModules: {
      extension: 'module.css',
      intermediateOutputPath: 'super-css-modules.css',
    },
    'ember-scoped-css': {
      passthrough: ['super-css-modules.css'],
      passthroughDestination: 'assets',
    },
```

and then I am able to use 

```css
@import './super-css-modules.css';
```

in my app.css and I can have both system working together 🎉 