### PR TITLE
allow babel to parse decorators

### DIFF
--- a/ember-scoped-css/src/lib/replaceHbsInJs.js
+++ b/ember-scoped-css/src/lib/replaceHbsInJs.js
@@ -8,6 +8,7 @@ const parseOptions = {
         sourceType: 'module',
         allowImportExportEverywhere: true,
         tokens: true,
+        plugins: ['decorators'],
       });
     },
   },


### PR DESCRIPTION
This allows the addon to work for code that is using decorators (pretty important stuff 😂) 

I don't think this needs to have any opinions on which decorators plugin it's using because it's just being used for parse 🤔 I have tested this and it's working 👍 