### PR TITLE
Drop 4.4 from testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,10 @@ jobs:
       fail-fast: false
       matrix:
         try-scenario:
-          - ember-lts-4.4
           - ember-lts-4.12
           - ember-lts-5.4
           - ember-lts-5.8
+          - ember-lts-5.12
           - ember-release
           - ember-beta
 

--- a/test-apps/embroider-app/config/ember-try.js
+++ b/test-apps/embroider-app/config/ember-try.js
@@ -40,6 +40,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-lts-5.12',
+        npm: {
+          devDependencies: {
+            'ember-source': '~5.12.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
This doesn't mean that 4.4 won't work with scoped css, it means that I don't want to figure out what dependency hooplah is needed to make the try scenario happy for 4.4