### PR TITLE
Specify cjs extension for cjs exported modules

### DIFF
--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -28,15 +28,15 @@
     },
     "./babel": {
       "import": "./src/build/public-exports/babel.js",
-      "require": "./dist/cjs/babel.js"
+      "require": "./dist/cjs/babel.cjs"
     },
     "./rollup": {
       "import": "./src/build/public-exports/rollup.js",
-      "require": "./dist/cjs/rollup.js"
+      "require": "./dist/cjs/rollup.cjs"
     },
     "./vite": {
       "import": "./src/build/public-exports/vite.js",
-      "require": "./dist/cjs/vite.js"
+      "require": "./dist/cjs/vite.cjs"
     },
     "./template-registry": {
       "types": "./template-registry.d.ts",


### PR DESCRIPTION
## Problem
Babel config files that are in cjs format are unable to import this modules babel export. This is due to the fact the package.json looks for cjs exports with a `.js` extension but tsdown was configured with the default configuration which outputs `.cjs` files.

## Solution
Change the extensions in the package.json exports for cjs modules to look for `.cjs`