### PR TITLE
Add CSS preprocessor support (SCSS/Sass/Less/Stylus)

### DIFF
--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -74,6 +74,7 @@
     "ember-template-recast": "^6.1.5",
     "glob": "^8.1.0",
     "postcss": "^8.5.3",
+    "postcss-scss": "^4.0.9",
     "postcss-selector-parser": "^6.0.16",
     "recast": "^0.23.7",
     "unplugin": "^2.3.10"

--- a/ember-scoped-css/pnpm-lock.yaml
+++ b/ember-scoped-css/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
+      postcss-scss:
+        specifier: ^4.0.9
+        version: 4.0.9(postcss@8.5.3)
       postcss-selector-parser:
         specifier: ^6.0.16
         version: 6.1.2
@@ -2993,6 +2996,12 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-scss@4.0.9:
+    resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.4.29
 
   postcss-selector-parser@6.1.2:
     resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
@@ -7125,6 +7134,10 @@ snapshots:
   pkg-entry-points@1.1.1: {}
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-scss@4.0.9(postcss@8.5.3):
+    dependencies:
+      postcss: 8.5.3
 
   postcss-selector-parser@6.1.2:
     dependencies:

--- a/ember-scoped-css/src/build/template-plugin.js
+++ b/ember-scoped-css/src/build/template-plugin.js
@@ -127,38 +127,24 @@ export function createPlugin(config) {
 
             addInfo(info);
 
-            /**
-             * For <style scoped inline lang="..."> we cannot preprocess at Babel-time
-             * (preprocessing is async and requires Vite's ResolvedConfig).
-             * Downgrade to non-inline: remove the tag and inject via virtual CSS module.
-             */
-            if (hasInlineAttribute(styleTag) && lang) {
+            if (hasInlineAttributeWithoutLang(styleTag)) {
+              /**
+               * This will be handled in ElementNode traversal
+               */
+              return;
+            }
+
+            if (lang) {
+              /**
+               * For <style scoped inline lang="..."> we cannot preprocess at Babel-time
+               * (preprocessing is async and requires Vite's ResolvedConfig).
+               * Remove the tag and inject via virtual CSS module and warn user.
+               */
               console.warn(
                 `[ember-scoped-css] <style scoped inline lang="${lang}"> is not supported ` +
                   `(preprocessing is async and cannot run at Babel-time). ` +
                   `Downgrading to non-inline: the style tag will be removed and injected as a virtual CSS module.`,
               );
-
-              let cssRequest = request.inline.create(
-                info.id,
-                postfix,
-                css,
-                lang,
-              );
-
-              env.meta.jsutils.importForSideEffect(cssRequest);
-
-              // Signal ElementNode visitor to remove the tag
-              styleTag.__downgradeInline = true;
-
-              return;
-            }
-
-            /**
-             * This will be handled in ElementNode traversal
-             */
-            if (hasInlineAttribute(styleTag)) {
-              return;
             }
 
             let cssRequest = request.inline.create(info.id, postfix, css, lang);
@@ -183,12 +169,7 @@ export function createPlugin(config) {
               );
             }
 
-            // Downgraded inline+lang: remove the tag (import was already emitted in Template visitor)
-            if (node.__downgradeInline) {
-              return null;
-            }
-
-            if (hasInlineAttribute(node)) {
+            if (hasInlineAttributeWithoutLang(node)) {
               let text = textContent(node);
               let scopedText = rewriteCss(
                 text,
@@ -209,7 +190,7 @@ export function createPlugin(config) {
             return null;
           }
 
-          if (hasInlineAttribute(node)) {
+          if (hasInlineAttributeWithoutLang(node)) {
             throw new Error(
               `<style inline> is not valid. Please add the scoped attribute: <style scoped inline>`,
             );
@@ -243,10 +224,14 @@ function hasScopedAttribute(node) {
   );
 }
 
-function hasInlineAttribute(node) {
+function hasInlineAttributeWithoutLang(node) {
   if (!node) return;
   if (node.tag !== 'style') return;
   if (node.type !== 'ElementNode') return;
+
+  if (getLangAttribute(node)) {
+    return false;
+  }
 
   return node.attributes.some(
     (attribute) => attribute.name === INLINE_ATTRIBUTE_NAME,

--- a/ember-scoped-css/src/build/template-plugin.js
+++ b/ember-scoped-css/src/build/template-plugin.js
@@ -122,9 +122,37 @@ export function createPlugin(config) {
 
           if (hasScopedAttribute(styleTag)) {
             let css = textContent(styleTag);
-            let info = getCSSContentInfo(css);
+            let lang = getLangAttribute(styleTag);
+            let info = getCSSContentInfo(css, lang);
 
             addInfo(info);
+
+            /**
+             * For <style scoped inline lang="..."> we cannot preprocess at Babel-time
+             * (preprocessing is async and requires Vite's ResolvedConfig).
+             * Downgrade to non-inline: remove the tag and inject via virtual CSS module.
+             */
+            if (hasInlineAttribute(styleTag) && lang) {
+              console.warn(
+                `[ember-scoped-css] <style scoped inline lang="${lang}"> is not supported ` +
+                  `(preprocessing is async and cannot run at Babel-time). ` +
+                  `Downgrading to non-inline: the style tag will be removed and injected as a virtual CSS module.`,
+              );
+
+              let cssRequest = request.inline.create(
+                info.id,
+                postfix,
+                css,
+                lang,
+              );
+
+              env.meta.jsutils.importForSideEffect(cssRequest);
+
+              // Signal ElementNode visitor to remove the tag
+              styleTag.__downgradeInline = true;
+
+              return;
+            }
 
             /**
              * This will be handled in ElementNode traversal
@@ -133,7 +161,7 @@ export function createPlugin(config) {
               return;
             }
 
-            let cssRequest = request.inline.create(info.id, postfix, css);
+            let cssRequest = request.inline.create(info.id, postfix, css, lang);
 
             env.meta.jsutils.importForSideEffect(cssRequest);
           }
@@ -153,6 +181,11 @@ export function createPlugin(config) {
               throw new Error(
                 '<style scoped> tags must be at the root of the template, they cannot be nested',
               );
+            }
+
+            // Downgraded inline+lang: remove the tag (import was already emitted in Template visitor)
+            if (node.__downgradeInline) {
+              return null;
             }
 
             if (hasInlineAttribute(node)) {
@@ -198,6 +231,7 @@ export function createPlugin(config) {
  */
 const SCOPED_ATTRIBUTE_NAME = 'scoped';
 const INLINE_ATTRIBUTE_NAME = 'inline';
+const LANG_ATTRIBUTE_NAME = 'lang';
 
 function hasScopedAttribute(node) {
   if (!node) return;
@@ -217,6 +251,31 @@ function hasInlineAttribute(node) {
   return node.attributes.some(
     (attribute) => attribute.name === INLINE_ATTRIBUTE_NAME,
   );
+}
+
+/**
+ * Returns the value of the `lang` attribute on a `<style>` node, or null if absent.
+ *
+ * @param {object} node
+ * @returns {string | null}
+ */
+function getLangAttribute(node) {
+  if (!node) return null;
+  if (node.tag !== 'style') return null;
+  if (node.type !== 'ElementNode') return null;
+
+  const attr = node.attributes.find(
+    (attribute) => attribute.name === LANG_ATTRIBUTE_NAME,
+  );
+
+  if (!attr) return null;
+
+  // The attribute value is a TextNode child of the AttrNode's value
+  const value = attr.value;
+
+  if (value?.type === 'TextNode') return value.chars || null;
+
+  return null;
 }
 
 function textContent(node) {

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -287,4 +287,50 @@ describe('lang attribute (SCSS preprocessor)', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('handles scoped lang="scss" BEM constructs', async () => {
+    let output = await transform(`
+    export const Foo = <template>
+      <div class="block block--modifier">hi</div>
+      <style scoped lang="scss">
+        .block {
+          &--modifier { color: green; }
+        }
+      </style>
+    </template>;
+  `);
+
+    expect(templateContentsOf(output)).toMatchInlineSnapshot(`
+    [
+      "<div class="block_e65d154a1 block--modifier_e65d154a1">hi</div>",
+    ]
+  `);
+  });
+
+  it('handles deeply nested BEM constructs', async () => {
+    let output = await transform(`
+    export const Foo = <template>
+      <div class="block block--modifier block--modifier--modifier block--modifier--modifier--modifier">hi</div>
+      <style scoped lang="scss">
+        .block {
+          &--modifier {
+            color: green;
+            &--modifier {
+              color: green;
+              &--modifier {
+                color: green;
+              }
+            }
+          }
+        }
+      </style>
+    </template>;
+  `);
+
+    expect(templateContentsOf(output)).toMatchInlineSnapshot(`
+      [
+        "<div class="block_e65d154a1 block--modifier_e65d154a1 block--modifier--modifier_e65d154a1 block--modifier--modifier--modifier_e65d154a1">hi</div>",
+      ]
+    `);
+  });
 });

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -242,8 +242,11 @@ describe('lang attribute (SCSS preprocessor)', () => {
     `);
 
     // The virtual module import should include &lang=scss
-    expect(output).toContain('lang=scss');
-    expect(output).toContain('.ember-scoped.css?css=');
+    expect(virtualImportUrlsOf(output)).toMatchInlineSnapshot(`
+      [
+        "./e65d154a1___css-3fbbf8c13a5ef6f5c5395268df4e8f37.ember-scoped.css?css=%0A%20%20%20%20%20%20%20%20%20%20.foo%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%26%3Ahover%20%7B%20color%3A%20blue%3B%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20color%3A%20red%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20&lang=scss",
+      ]
+    `);
   });
 
   it('scoped inline lang="scss" is downgraded to non-inline (warning emitted, style tag removed)', async () => {

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -28,6 +28,31 @@ async function transform(file: string, config = {}) {
   return result?.code;
 }
 
+function virtualImportUrlsOf(file: string | null | undefined) {
+  if (!file) return [];
+
+  let j = jscodeshift;
+
+  let result: string[] = [];
+
+  j(file)
+    .find(j.ImportDeclaration, {
+      source: {
+        value: (value) =>
+          typeof value === 'string' && value.includes('.ember-scoped.css?css='),
+      },
+    })
+    .forEach((path) => {
+      let source = path.node.source.value;
+
+      if (typeof source === 'string') {
+        result.push(source);
+      }
+    });
+
+  return result;
+}
+
 function templateContentsOf(file: string | null | undefined) {
   if (!file) return [];
 
@@ -216,6 +241,8 @@ describe('lang attribute (SCSS preprocessor)', () => {
       ]
     `);
 
+    console.log(output);
+
     // The virtual module import should include &lang=scss
     expect(output).toContain('lang=scss');
     expect(output).toContain('.ember-scoped.css?css=');
@@ -244,8 +271,7 @@ describe('lang attribute (SCSS preprocessor)', () => {
     `);
 
     // A virtual module import should have been emitted with lang=scss
-    expect(output).toContain('lang=scss');
-    expect(output).toContain('.ember-scoped.css?css=');
+    expect(virtualImportUrlsOf(output)[0]).toContain('lang=scss');
 
     // A warning should have been logged
     expect(warnSpy).toHaveBeenCalledWith(

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -38,8 +38,7 @@ function virtualImportUrlsOf(file: string | null | undefined) {
   j(file)
     .find(j.ImportDeclaration, {
       source: {
-        value: (value) =>
-          typeof value === 'string' && value.includes('.ember-scoped.css?css='),
+        value: (value: string) => value.includes('.ember-scoped.css?css='),
       },
     })
     .forEach((path) => {

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -271,7 +271,11 @@ describe('lang attribute (SCSS preprocessor)', () => {
     `);
 
     // A virtual module import should have been emitted with lang=scss
-    expect(virtualImportUrlsOf(output)[0]).toContain('lang=scss');
+    expect(virtualImportUrlsOf(output)).toMatchInlineSnapshot(`
+      [
+        "./e65d154a1___css-3fbbf8c13a5ef6f5c5395268df4e8f37.ember-scoped.css?css=%0A%20%20%20%20%20%20%20%20%20%20.foo%20%7B%0A%20%20%20%20%20%20%20%20%20%20%20%20%26%3Ahover%20%7B%20color%3A%20blue%3B%20%7D%0A%20%20%20%20%20%20%20%20%20%20%20%20color%3A%20red%3B%0A%20%20%20%20%20%20%20%20%20%20%7D%0A%20%20%20%20%20%20%20%20&lang=scss",
+      ]
+    `);
 
     // A warning should have been logged
     expect(warnSpy).toHaveBeenCalledWith(

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -241,8 +241,6 @@ describe('lang attribute (SCSS preprocessor)', () => {
       ]
     `);
 
-    console.log(output);
-
     // The virtual module import should include &lang=scss
     expect(output).toContain('lang=scss');
     expect(output).toContain('.ember-scoped.css?css=');

--- a/ember-scoped-css/src/build/template-plugin.test.ts
+++ b/ember-scoped-css/src/build/template-plugin.test.ts
@@ -2,7 +2,7 @@ import * as babel from '@babel/core';
 import { stripIndent } from 'common-tags';
 import { Preprocessor } from 'content-tag';
 import jscodeshift from 'jscodeshift';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { createPlugin } from './template-plugin.js';
 
@@ -193,4 +193,67 @@ it('scoped inline transforms correctly', async () => {
     </style>",
     ]
   `);
+});
+
+describe('lang attribute (SCSS preprocessor)', () => {
+  it('scoped lang="scss" emits virtual import with lang param and rewrites classes', async () => {
+    let output = await transform(`
+      export const Foo = <template>
+        <div class="foo">hi</div>
+        <style scoped lang="scss">
+          .foo {
+            &:hover { color: blue; }
+            color: red;
+          }
+        </style>
+      </template>;
+    `);
+
+    // The style tag should be removed (it's a virtual module, not inline)
+    expect(templateContentsOf(output)).toMatchInlineSnapshot(`
+      [
+        "<div class="foo_e65d154a1">hi</div>",
+      ]
+    `);
+
+    // The virtual module import should include &lang=scss
+    expect(output).toContain('lang=scss');
+    expect(output).toContain('.ember-scoped.css?css=');
+  });
+
+  it('scoped inline lang="scss" is downgraded to non-inline (warning emitted, style tag removed)', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    let output = await transform(`
+      export const Foo = <template>
+        <div class="foo">hi</div>
+        <style scoped inline lang="scss">
+          .foo {
+            &:hover { color: blue; }
+            color: red;
+          }
+        </style>
+      </template>;
+    `);
+
+    // The style tag should be removed (downgraded to non-inline)
+    expect(templateContentsOf(output)).toMatchInlineSnapshot(`
+      [
+        "<div class="foo_e65d154a1">hi</div>",
+      ]
+    `);
+
+    // A virtual module import should have been emitted with lang=scss
+    expect(output).toContain('lang=scss');
+    expect(output).toContain('.ember-scoped.css?css=');
+
+    // A warning should have been logged
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '<style scoped inline lang="scss"> is not supported',
+      ),
+    );
+
+    warnSpy.mockRestore();
+  });
 });

--- a/ember-scoped-css/src/build/unplugin-colocated.js
+++ b/ember-scoped-css/src/build/unplugin-colocated.js
@@ -1,10 +1,20 @@
 import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { rewriteCss } from '../lib/css/rewrite.js';
 import { request } from '../lib/request.js';
 
 const META = 'scoped-css:colocated';
+
+/** File extensions that Vite can preprocess via its CSS preprocessor pipeline */
+const PREPROCESSED_EXTENSIONS = new Set([
+  '.scss',
+  '.sass',
+  '.less',
+  '.styl',
+  '.stylus',
+]);
 
 /**
  * Plugin for supporting colocated styles
@@ -15,6 +25,12 @@ const META = 'scoped-css:colocated';
  */
 export function colocated(options = {}) {
   const CWD = process.cwd();
+
+  /** @type {import('vite').ResolvedConfig | undefined} */
+  let viteConfig;
+
+  /** @type {((code: string, filename: string, config: unknown) => Promise<{ code: string }>) | undefined} */
+  let preprocessCSS;
 
   /**
    *
@@ -73,17 +89,56 @@ export function colocated(options = {}) {
       }
     },
     vite: {
+      async configResolved(config) {
+        viteConfig = config;
+
+        // Resolve Vite's preprocessCSS from the app root to ensure we find
+        // the correct Vite installation (not a stale or missing one).
+        try {
+          const require = createRequire(
+            path.resolve(config.root, 'package.json'),
+          );
+          const vitePath = require.resolve('vite');
+          const viteModule = await import(vitePath);
+
+          preprocessCSS = viteModule.preprocessCSS;
+        } catch {
+          // Vite may not be resolvable from the config root in some setups;
+          // preprocessor support for colocated .scss files will throw a clear
+          // error at load time if used.
+        }
+      },
+
       /**
        * There may not be meta for this request yet.
        *
        * @param {*} id
        */
-      load(id) {
+      async load(id) {
         if (request.is.colocated(id)) {
           const parsed = request.colocated.decode(id);
 
           let code = readFileSync(parsed.fileName, 'utf-8');
           let relativeFilePath = path.relative(CWD, parsed.fileName);
+
+          const ext = path.extname(parsed.fileName).toLowerCase();
+
+          if (PREPROCESSED_EXTENSIONS.has(ext)) {
+            if (!viteConfig || !preprocessCSS) {
+              throw new Error(
+                `[ember-scoped-css] Colocated CSS file with extension '${ext}' requires Vite. ` +
+                  `CSS preprocessing is only supported in Vite builds.`,
+              );
+            }
+
+            const result = await preprocessCSS(
+              code,
+              parsed.fileName,
+              viteConfig,
+            );
+
+            code = result.code;
+          }
 
           let css = rewriteCss(
             code,

--- a/ember-scoped-css/src/build/unplugin-colocated.js
+++ b/ember-scoped-css/src/build/unplugin-colocated.js
@@ -95,9 +95,7 @@ export function colocated(options = {}) {
         // Resolve Vite's preprocessCSS from the app root to ensure we find
         // the correct Vite installation (not a stale or missing one).
         try {
-          const require = createRequire(
-            path.resolve(config.root, 'package.json'),
-          );
+          const require = createRequire(config.root);
           const vitePath = require.resolve('vite');
           const viteModule = await import(vitePath);
 

--- a/ember-scoped-css/src/build/unplugin-inline.js
+++ b/ember-scoped-css/src/build/unplugin-inline.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'node:module';
 import path from 'node:path';
 
 import { rewriteCss } from '../lib/css/rewrite.js';
@@ -17,6 +18,12 @@ const META = 'scoped-css:inline';
 export function inline(options = {}) {
   const CWD = process.cwd();
 
+  /** @type {import('vite').ResolvedConfig | undefined} */
+  let viteConfig;
+
+  /** @type {((code: string, filename: string, config: unknown) => Promise<{ code: string }>) | undefined} */
+  let preprocessCSS;
+
   /**
    * @param {string} id the request id / what was imported
    */
@@ -25,22 +32,14 @@ export function inline(options = {}) {
 
     const relativeFilePath = path.relative(CWD, filePath);
 
-    const css = rewriteCss(
-      parsed.css,
-      parsed.postfix,
-      `<inline>/${relativeFilePath}`,
-      options.layerName,
-    );
-
-    const nextId = filePath.split('?')[0];
-
     return {
-      id: nextId,
+      id: filePath.split('?')[0],
       meta: {
         [META]: {
-          css,
+          rawCss: parsed.css,
           postfix: parsed.postfix,
           fileName: relativeFilePath,
+          lang: parsed.lang,
         },
       },
     };
@@ -60,12 +59,55 @@ export function inline(options = {}) {
         return buildResponse(id, filePath);
       }
     },
-    load(id) {
+    async load(id) {
       const meta = this.getModuleInfo(id)?.meta?.[META];
 
       if (meta) {
-        return meta.css;
+        let rawCss = meta.rawCss;
+
+        if (meta.lang) {
+          if (!viteConfig || !preprocessCSS) {
+            throw new Error(
+              `[ember-scoped-css] <style scoped lang="${meta.lang}"> requires Vite. ` +
+                `CSS preprocessing via the 'lang' attribute is only supported in Vite builds.`,
+            );
+          }
+
+          const fakeFilename = `${meta.fileName}.${meta.lang}`;
+          const result = await preprocessCSS(rawCss, fakeFilename, viteConfig);
+
+          rawCss = result.code;
+        }
+
+        const css = rewriteCss(
+          rawCss,
+          meta.postfix,
+          `<inline>/${meta.fileName}`,
+          options.layerName,
+        );
+
+        return css;
       }
+    },
+    vite: {
+      async configResolved(config) {
+        viteConfig = config;
+
+        // Resolve Vite's preprocessCSS from the app root to ensure we find
+        // the correct Vite installation (not a stale or missing one).
+        try {
+          const require = createRequire(
+            path.resolve(config.root, 'package.json'),
+          );
+          const vitePath = require.resolve('vite');
+          const viteModule = await import(vitePath);
+
+          preprocessCSS = viteModule.preprocessCSS;
+        } catch {
+          // Vite may not be resolvable from the config root in some setups;
+          // lang= support will throw a clear error at load time if used.
+        }
+      },
     },
   };
 }

--- a/ember-scoped-css/src/build/unplugin-inline.js
+++ b/ember-scoped-css/src/build/unplugin-inline.js
@@ -96,9 +96,7 @@ export function inline(options = {}) {
         // Resolve Vite's preprocessCSS from the app root to ensure we find
         // the correct Vite installation (not a stale or missing one).
         try {
-          const require = createRequire(
-            path.resolve(config.root, 'package.json'),
-          );
+          const require = createRequire(config.root);
           const vitePath = require.resolve('vite');
           const viteModule = await import(vitePath);
 

--- a/ember-scoped-css/src/lib/css/rewrite.js
+++ b/ember-scoped-css/src/lib/css/rewrite.js
@@ -21,7 +21,7 @@ function isDeclaration(node) {
  * NOTE: "keyframes" is a singular definition, in that it's a block containing keyframes
  *       using `@keyframes {}` with only one thing on the inside doesn't make sense.
  */
-function rewriteReferencable(node, postfix) {
+function rewriteReferenceable(node, postfix) {
   let originalName = node.params;
   let postfixedName = node.params + SEP + postfix;
 
@@ -90,25 +90,25 @@ export function rewriteCss(css, postfix, fileName, layerName) {
    * kind => originalName => postfixedName
    * @type {{ [kind: string]: { [originalName: string]: string }}}
    */
-  const referencables = {
+  const referenceables = {
     keyframes: {},
     'counter-style': {},
     'position-try': {},
     property: {},
   };
 
-  const availableReferencables = new Set(Object.keys(referencables));
+  const availableReferenceables = new Set(Object.keys(referenceables));
 
   function isReferenceable(node) {
     if (node.type !== 'atrule') return;
 
-    return availableReferencables.has(node.name);
+    return availableReferenceables.has(node.name);
   }
 
   function updateDirectReferences(node) {
     if (!node.value) return;
 
-    for (let [, map] of Object.entries(referencables)) {
+    for (let [, map] of Object.entries(referenceables)) {
       if (map[node.value]) {
         node.value = map[node.value];
       }
@@ -118,11 +118,11 @@ export function rewriteCss(css, postfix, fileName, layerName) {
   function updateShorthandContents(node) {
     if (node.prop === 'animation') {
       let parts = node.value.split(' ');
-      let match = parts.filter((x) => referencables.keyframes[x]);
+      let match = parts.filter((x) => referenceables.keyframes[x]);
 
       if (match.length) {
         match.forEach((x) => {
-          let replacement = referencables.keyframes[x];
+          let replacement = referenceables.keyframes[x];
 
           if (!replacement) return;
 
@@ -131,7 +131,9 @@ export function rewriteCss(css, postfix, fileName, layerName) {
       }
     }
 
-    for (let [lookFor, replaceWith] of Object.entries(referencables.property)) {
+    for (let [lookFor, replaceWith] of Object.entries(
+      referenceables.property,
+    )) {
       let lookForVar = `var(${lookFor})`;
       let replaceWithVar = `var(${replaceWith})`;
 
@@ -141,27 +143,27 @@ export function rewriteCss(css, postfix, fileName, layerName) {
 
   /**
    * We have to do two passes:
-   * 1. postfix all the referencable syntax
+   * 1. postfix all the referenceable syntax
    * 2. postfix as normal, but also checking values of CSS properties
-   *    that could match postfixed referencables from step 1
+   *    that could match postfixed referenceables from step 1
    */
 
-  // Step 1: find referencables
+  // Step 1: find referenceables
   ast.walk((node) => {
     /**
      * @keyframes, @counter-style, etc
      */
     if (isReferenceable(node)) {
       let name = node.name;
-      let { originalName, postfixedName } = rewriteReferencable(node, postfix);
+      let { originalName, postfixedName } = rewriteReferenceable(node, postfix);
 
-      referencables[name][originalName] = postfixedName;
+      referenceables[name][originalName] = postfixedName;
 
       return;
     }
   });
 
-  // Step 2: postfix and update refenced referencables
+  // Step 2: postfix and update referenced referenceables
   ast.walk((node) => {
     if (isDeclaration(node)) {
       updateDirectReferences(node);

--- a/ember-scoped-css/src/lib/css/rewrite.js
+++ b/ember-scoped-css/src/lib/css/rewrite.js
@@ -99,7 +99,7 @@ export function rewriteCss(css, postfix, fileName, layerName) {
 
   const availableReferencables = new Set(Object.keys(referencables));
 
-  function isReferencable(node) {
+  function isReferenceable(node) {
     if (node.type !== 'atrule') return;
 
     return availableReferencables.has(node.name);
@@ -151,7 +151,7 @@ export function rewriteCss(css, postfix, fileName, layerName) {
     /**
      * @keyframes, @counter-style, etc
      */
-    if (isReferencable(node)) {
+    if (isReferenceable(node)) {
       let name = node.name;
       let { originalName, postfixedName } = rewriteReferencable(node, postfix);
 

--- a/ember-scoped-css/src/lib/css/utils.js
+++ b/ember-scoped-css/src/lib/css/utils.js
@@ -57,6 +57,7 @@ export function getCSSContentInfo(css, lang) {
   ast.walk((node) => {
     if (node.type === 'rule') {
       const selector = isScss ? resolveNestedSassSelector(node) : node.selector;
+
       getClassesAndTags(selector, classes, tags);
     }
   });

--- a/ember-scoped-css/src/lib/css/utils.js
+++ b/ember-scoped-css/src/lib/css/utils.js
@@ -52,15 +52,48 @@ export function getCSSContentInfo(css, lang) {
 
   const ast = postcss.parse(css, parseOptions);
 
+  const isScss = lang === 'scss' || lang === 'sass';
+
   ast.walk((node) => {
     if (node.type === 'rule') {
-      getClassesAndTags(node.selector, classes, tags);
+      const selector = isScss ? resolveNestedSassSelector(node) : node.selector;
+      getClassesAndTags(selector, classes, tags);
     }
   });
 
   let id = hash(css);
 
   return { classes, tags, css, id };
+}
+
+/**
+ * Resolves a nested SCSS selector by substituting `&` with the fully-resolved
+ * parent selector, recursively. This converts e.g. `&--modifier` (child of
+ * `.block`) into `.block--modifier`, and handles arbitrary nesting depth so
+ * that `&--modifier` inside `&--modifier` inside `.block` yields
+ * `.block--modifier--modifier`.
+ *
+ * @param {import('postcss').Rule} node
+ * @return {string}
+ */
+function resolveNestedSassSelector(node) {
+  const { selector } = node;
+
+  if (!selector.includes('&')) {
+    return selector;
+  }
+
+  const parent = node.parent;
+
+  if (!parent || parent.type !== 'rule') {
+    // No parent rule — `&` has nothing to substitute, return as-is
+    return selector;
+  }
+
+  // Recursively resolve the parent first, then substitute into this selector
+  const resolvedParent = resolveNestedSassSelector(parent);
+
+  return selector.replace(/&/g, resolvedParent);
 }
 
 function getClassesAndTags(sel, classes, tags) {
@@ -124,6 +157,34 @@ if (import.meta.vitest) {
     expect([...classes]).toMatchInlineSnapshot(`
       [
         "block",
+        "block--modifier",
+      ]
+    `);
+  });
+
+  it('should parse SCSS deeply nested BEM when lang=sass', function () {
+    const scss = `
+      $base-color: green;
+      .block {
+        &--modifier {
+          color: $base-color;
+          &--modifier {
+            color: $base-color;
+            &--modifier {
+              color: $base-color;
+            }
+          }
+        }
+      }
+    `;
+    const { classes } = getCSSContentInfo(scss, 'sass');
+
+    expect([...classes]).toMatchInlineSnapshot(`
+      [
+        "block",
+        "block--modifier",
+        "block--modifier--modifier",
+        "block--modifier--modifier--modifier",
       ]
     `);
   });

--- a/ember-scoped-css/src/lib/css/utils.js
+++ b/ember-scoped-css/src/lib/css/utils.js
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'fs';
 import postcss from 'postcss';
+import scssSyntax from 'postcss-scss';
 import parser from 'postcss-selector-parser';
 
 import { md5 } from '../path/md5.js';
@@ -39,13 +40,17 @@ export function getCSSInfo(cssPath) {
  * to see if we need to leave it alone or transform it
  *
  * @param {string} css the CSS's contents
+ * @param {string} [lang] optional language hint (e.g. 'scss', 'sass', 'less')
  * @return {{ classes: Set<string>, tags: Set<string>, css: string, id: string }}
  */
-export function getCSSContentInfo(css) {
+export function getCSSContentInfo(css, lang) {
   const classes = new Set();
   const tags = new Set();
 
-  const ast = postcss.parse(css);
+  const parseOptions =
+    lang === 'scss' || lang === 'sass' ? { syntax: scssSyntax } : {};
+
+  const ast = postcss.parse(css, parseOptions);
 
   ast.walk((node) => {
     if (node.type === 'rule') {
@@ -84,5 +89,29 @@ if (import.meta.vitest) {
     expect([...classes]).to.have.members(['baz', 'bar']);
     expect(tags.size).to.equal(1);
     expect([...tags]).to.have.members(['div']);
+  });
+
+  it('should parse SCSS nesting syntax without crashing when lang=scss', function () {
+    const scss = `
+      .parent {
+        &:hover { color: blue; }
+        .child { font-size: 14px; }
+        color: red;
+      }
+    `;
+    const { classes } = getCSSContentInfo(scss, 'scss');
+
+    expect([...classes]).to.have.members(['parent', 'child']);
+  });
+
+  it('should parse SCSS nesting syntax without crashing when lang=sass', function () {
+    const scss = `
+      .block {
+        &--modifier { color: green; }
+      }
+    `;
+    const { classes } = getCSSContentInfo(scss, 'sass');
+
+    expect([...classes]).to.have.members(['block']);
   });
 }

--- a/ember-scoped-css/src/lib/css/utils.js
+++ b/ember-scoped-css/src/lib/css/utils.js
@@ -93,25 +93,38 @@ if (import.meta.vitest) {
 
   it('should parse SCSS nesting syntax without crashing when lang=scss', function () {
     const scss = `
+      $base-color: #c6538c;
+      $border-dark: rgba($base-color, 0.88);
+
       .parent {
-        &:hover { color: blue; }
-        .child { font-size: 14px; }
+        &:hover { color: $base-color; }
+        .child { border: 1px solid $border-dark; }
         color: red;
       }
     `;
     const { classes } = getCSSContentInfo(scss, 'scss');
 
-    expect([...classes]).to.have.members(['parent', 'child']);
+    expect([...classes]).toMatchInlineSnapshot(`
+      [
+        "parent",
+        "child",
+      ]
+    `);
   });
 
   it('should parse SCSS nesting syntax without crashing when lang=sass', function () {
     const scss = `
+      $base-color: green;
       .block {
-        &--modifier { color: green; }
+        &--modifier { color: $base-color; }
       }
     `;
     const { classes } = getCSSContentInfo(scss, 'sass');
 
-    expect([...classes]).to.have.members(['block']);
+    expect([...classes]).toMatchInlineSnapshot(`
+      [
+        "block",
+      ]
+    `);
   });
 }

--- a/ember-scoped-css/src/lib/request.js
+++ b/ember-scoped-css/src/lib/request.js
@@ -19,9 +19,16 @@ export const request = {
      * @param {string} cssHash the hash of the CSS contents
      * @param {string} postfix the hash of the file that _includes_ the linked file
      * @param {string} cssContents the contents of the CSS file
+     * @param {string} [lang] optional preprocessor language (e.g. 'scss', 'sass', 'less')
      */
-    create(cssHash, postfix, cssContents) {
-      return `./${postfix}${SEP}${cssHash}.${KEY}?css=${encodeURIComponent(cssContents)}`;
+    create(cssHash, postfix, cssContents, lang) {
+      let url = `./${postfix}${SEP}${cssHash}.${KEY}?css=${encodeURIComponent(cssContents)}`;
+
+      if (lang) {
+        url += `&lang=${encodeURIComponent(lang)}`;
+      }
+
+      return url;
     },
     decode(request) {
       let [left, qps] = request.split('?');
@@ -37,6 +44,7 @@ export const request = {
         postfix,
         css: search.get('css'),
         from: search.get('from'),
+        lang: search.get('lang'),
       };
     },
   },

--- a/test-apps/vite-app/package.json
+++ b/test-apps/vite-app/package.json
@@ -62,6 +62,7 @@
     "prettier-plugin-ember-template-tag": "2.0.5",
     "qunit": "^3.0.0-alpha.4",
     "qunit-dom": "^3.4.0",
+    "sass": "^1.86.0",
     "typescript": "^5.7.3",
     "vite": "6.2.5"
   },

--- a/test-apps/vite-app/pnpm-lock.yaml
+++ b/test-apps/vite-app/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 1.17.1
       '@embroider/vite':
         specifier: 1.0.2
-        version: 1.0.2(883799c7abf839639e44d43efa588fb5)
+        version: 1.0.2(6d3d6ae83b3399d52b2e9d14699ad427)
       '@rollup/plugin-babel':
         specifier: 6.1.0
         version: 6.1.0(@babel/core@7.28.5)(rollup@4.34.9)
@@ -101,12 +101,15 @@ importers:
       qunit-dom:
         specifier: ^3.4.0
         version: 3.4.0
+      sass:
+        specifier: ^1.86.0
+        version: 1.98.0
       typescript:
         specifier: ^5.7.3
         version: 5.8.2
       vite:
         specifier: 6.2.5
-        version: 6.2.5(@types/node@22.13.9)(terser@5.39.0)
+        version: 6.2.5(595f40adc7109433ecb26edcb56f1aa3)
 
 packages:
 
@@ -1134,6 +1137,88 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@parcel/watcher-android-arm64@2.5.6':
+    resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    resolution: {integrity: sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    resolution: {integrity: sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    resolution: {integrity: sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    resolution: {integrity: sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    resolution: {integrity: sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    resolution: {integrity: sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==}
+    engines: {node: '>= 10.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@parcel/watcher@2.5.6':
+    resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
+    engines: {node: '>= 10.0.0'}
+
   '@pnpm/constants@10.0.0':
     resolution: {integrity: sha512-dxIXcW1F1dxIGfye2JXE7Q8WVwYB0axVzdBOkvE1WKIVR4xjB8e6k/Dkjo7DpbyfW5Vu2k21p6dyM32YLSAWoQ==}
     engines: {node: '>=18.12'}
@@ -1928,6 +2013,10 @@ packages:
   charm@1.0.2:
     resolution: {integrity: sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   ci-info@4.1.0:
     resolution: {integrity: sha512-HutrvTNsF48wnxkzERIXOe5/mlcfFcbfCmwcg6CJnizbSue78AbDt+1cgl26zwn61WFxhcPykPfZrbqjGmBb4A==}
     engines: {node: '>=8'}
@@ -2439,6 +2528,10 @@ packages:
   detect-indent@7.0.1:
     resolution: {integrity: sha512-Mc7QhQ8s+cLrnUfU/Ji94vG/r8M26m8f++vyres4ZoojaRDpZ1eSIh/EpzLNwlWuvzSZ3UbDFspjFvTDXe6e/g==}
     engines: {node: '>=12.20'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
 
   detect-newline@4.0.1:
     resolution: {integrity: sha512-qE3Veg1YXzGHQhlA6jzebZN2qVf6NX+A7m7qlhCGG30dJixrAQhYOsJjsnBjJkCSmuOPpCk30145fr8FV0bzog==}
@@ -3357,6 +3450,9 @@ packages:
     resolution: {integrity: sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==}
     engines: {node: '>= 4'}
 
+  immutable@5.1.5:
+    resolution: {integrity: sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -4037,6 +4133,9 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
@@ -4439,6 +4538,10 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recast@0.18.10:
     resolution: {integrity: sha512-XNvYvkfdAN9QewbrxeTOjgINkdY/odTgTS56ZNEWL9Ml0weT4T3sFtvnTuF+Gxyu46ANcRm1ntrF6F5LAJPAaQ==}
     engines: {node: '>= 4'}
@@ -4686,6 +4789,11 @@ packages:
   sane@5.0.1:
     resolution: {integrity: sha512-9/0CYoRz0MKKf04OMCO3Qk3RQl1PAwWAhPSQSym4ULiLpTZnrY1JoZU0IEikHu8kdk2HvKT/VwQMq/xFZ8kh1Q==}
     engines: {node: 10.* || >= 12.*}
+    hasBin: true
+
+  sass@1.98.0:
+    resolution: {integrity: sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==}
+    engines: {node: '>=14.0.0'}
     hasBin: true
 
   saxes@6.0.0:
@@ -6435,7 +6543,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@embroider/vite@1.0.2(883799c7abf839639e44d43efa588fb5)':
+  '@embroider/vite@1.0.2(6d3d6ae83b3399d52b2e9d14699ad427)':
     dependencies:
       '@babel/core': 7.28.5
       '@embroider/core': 4.0.1
@@ -6453,7 +6561,7 @@ snapshots:
       send: 0.18.0
       source-map-url: 0.4.1
       terser: 5.39.0
-      vite: 6.2.5(@types/node@22.13.9)(terser@5.39.0)
+      vite: 6.2.5(595f40adc7109433ecb26edcb56f1aa3)
     transitivePeerDependencies:
       - '@glint/template'
       - bufferutil
@@ -6842,6 +6950,67 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@parcel/watcher-android-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-darwin-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-freebsd-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-arm64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-glibc@2.5.6':
+    optional: true
+
+  '@parcel/watcher-linux-x64-musl@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-arm64@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-ia32@2.5.6':
+    optional: true
+
+  '@parcel/watcher-win32-x64@2.5.6':
+    optional: true
+
+  '@parcel/watcher@2.5.6':
+    dependencies:
+      detect-libc: 2.1.2
+      is-glob: 4.0.3
+      node-addon-api: 7.1.1
+      picomatch: 4.0.3
+    optionalDependencies:
+      '@parcel/watcher-android-arm64': 2.5.6
+      '@parcel/watcher-darwin-arm64': 2.5.6
+      '@parcel/watcher-darwin-x64': 2.5.6
+      '@parcel/watcher-freebsd-x64': 2.5.6
+      '@parcel/watcher-linux-arm-glibc': 2.5.6
+      '@parcel/watcher-linux-arm-musl': 2.5.6
+      '@parcel/watcher-linux-arm64-glibc': 2.5.6
+      '@parcel/watcher-linux-arm64-musl': 2.5.6
+      '@parcel/watcher-linux-x64-glibc': 2.5.6
+      '@parcel/watcher-linux-x64-musl': 2.5.6
+      '@parcel/watcher-win32-arm64': 2.5.6
+      '@parcel/watcher-win32-ia32': 2.5.6
+      '@parcel/watcher-win32-x64': 2.5.6
+    optional: true
 
   '@pnpm/constants@10.0.0': {}
 
@@ -7872,6 +8041,10 @@ snapshots:
     dependencies:
       inherits: 2.0.4
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   ci-info@4.1.0: {}
 
   class-utils@0.3.6:
@@ -8191,6 +8364,9 @@ snapshots:
   detect-file@1.0.0: {}
 
   detect-indent@7.0.1: {}
+
+  detect-libc@2.1.2:
+    optional: true
 
   detect-newline@4.0.1: {}
 
@@ -9712,6 +9888,8 @@ snapshots:
 
   ignore@7.0.3: {}
 
+  immutable@5.1.5: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -10413,6 +10591,9 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-addon-api@7.1.1:
+    optional: true
+
   node-int64@0.4.0: {}
 
   node-notifier@10.0.1:
@@ -10791,6 +10972,8 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  readdirp@4.1.2: {}
+
   recast@0.18.10:
     dependencies:
       ast-types: 0.13.3
@@ -11073,6 +11256,14 @@ snapshots:
       micromatch: 4.0.8
       minimist: 1.2.8
       walker: 1.0.8
+
+  sass@1.98.0:
+    dependencies:
+      chokidar: 4.0.3
+      immutable: 5.1.5
+      source-map-js: 1.2.1
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
 
   saxes@6.0.0:
     dependencies:
@@ -11848,7 +12039,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@6.2.5(@types/node@22.13.9)(terser@5.39.0):
+  vite@6.2.5(595f40adc7109433ecb26edcb56f1aa3):
     dependencies:
       esbuild: 0.25.0
       postcss: 8.5.3
@@ -11856,6 +12047,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.13.9
       fsevents: 2.3.3
+      sass: 1.98.0
       terser: 5.39.0
 
   w3c-xmlserializer@5.0.0:

--- a/test-apps/vite-app/src/components/in-app/_mixins.scss
+++ b/test-apps/vite-app/src/components/in-app/_mixins.scss
@@ -1,0 +1,22 @@
+@mixin button-base($bg, $fg) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 14px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  background-color: $bg;
+  color: $fg;
+}
+
+@mixin visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
+++ b/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
@@ -1,6 +1,9 @@
 export const ScopedScss = <template>
   <p class="scss-hi">hello from scss</p>
-  <style scoped lang="scss">
+  <style
+    scoped
+    lang="scss"
+  >
     .scss-hi {
       $color: rgb(200, 0, 100);
 
@@ -18,7 +21,10 @@ export const ScopedScssMixins = <template>
     <span class="card-title">title</span>
     <span class="card-body">body</span>
   </div>
-  <style scoped lang="scss">
+  <style
+    scoped
+    lang="scss"
+  >
     @mixin flex-center($gap: 0px) {
       display: flex;
       align-items: center;
@@ -56,7 +62,10 @@ export const ScopedScssMixins = <template>
 export const ScopedScssAtUse = <template>
   <button type="button" class="btn-primary">click me</button>
   <span class="sr-label">accessible label</span>
-  <style scoped lang="scss">
+  <style
+    scoped
+    lang="scss"
+  >
     @use './mixins' as m;
 
     .btn-primary {

--- a/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
+++ b/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
@@ -1,0 +1,70 @@
+export const ScopedScss = <template>
+  <p class="scss-hi">hello from scss</p>
+  <style scoped lang="scss">
+    .scss-hi {
+      $color: rgb(200, 0, 100);
+
+      color: $color;
+
+      &:focus {
+        outline: none;
+      }
+    }
+  </style>
+</template>;
+
+export const ScopedScssMixins = <template>
+  <div class="card">
+    <span class="card-title">title</span>
+    <span class="card-body">body</span>
+  </div>
+  <style scoped lang="scss">
+    @mixin flex-center($gap: 0px) {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: $gap;
+    }
+
+    @mixin font-style($size, $weight) {
+      font-size: $size;
+      font-weight: $weight;
+    }
+
+    $border-radius: 4px;
+    $padding: 8px;
+
+    .card {
+      @include flex-center(4px);
+      padding: $padding;
+      border-radius: $border-radius;
+      background-color: rgb(240, 240, 255);
+
+      .card-title {
+        @include font-style(18px, 700);
+        color: rgb(10, 20, 200);
+      }
+
+      .card-body {
+        @include font-style(14px, 400);
+        color: rgb(50, 50, 50);
+      }
+    }
+  </style>
+</template>;
+
+export const ScopedScssAtUse = <template>
+  <button type="button" class="btn-primary">click me</button>
+  <span class="sr-label">accessible label</span>
+  <style scoped lang="scss">
+    @use './mixins' as m;
+
+    .btn-primary {
+      @include m.button-base(rgb(0, 112, 240), rgb(255, 255, 255));
+    }
+
+    .sr-label {
+      @include m.visually-hidden;
+    }
+  </style>
+</template>;

--- a/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
+++ b/test-apps/vite-app/src/components/in-app/scoped-scss.gjs
@@ -77,3 +77,19 @@ export const ScopedScssAtUse = <template>
     }
   </style>
 </template>;
+
+export const ScopedBEM = <template>
+  <p class="hi hi--modifier">hi</p>
+  <style
+    scoped
+    lang="scss"
+  >
+    .hi {
+      color: rgb(0, 0, 200);
+      &--modifier {
+        font-weight: 700;
+      }
+    }
+
+  </style>
+</template>;

--- a/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
+++ b/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
@@ -1,0 +1,75 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import {
+  ScopedScss,
+  ScopedScssMixins,
+  ScopedScssAtUse,
+} from 'vite-app/components/in-app/scoped-scss';
+
+import { scopedClass } from 'ember-scoped-css/test-support';
+
+module('[In App] scoped scss', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('scss styles are applied and class is scoped', async function (assert) {
+    await render(ScopedScss);
+
+    assert
+      .dom('p')
+      .hasClass(
+        scopedClass('scss-hi', 'vite-app/components/in-app/scoped-scss'),
+      );
+    assert.dom('p').hasStyle({ color: 'rgb(200, 0, 100)' });
+  });
+
+  test('mixins, variables, and nesting are compiled and scoped correctly', async function (assert) {
+    await render(ScopedScssMixins);
+
+    const scope = 'vite-app/components/in-app/scoped-scss';
+
+    const cardClass = scopedClass('card', scope);
+    const titleClass = scopedClass('card-title', scope);
+    const bodyClass = scopedClass('card-body', scope);
+
+    assert.dom(`.${cardClass}`).exists();
+    assert
+      .dom(`.${cardClass}`)
+      .hasStyle({ display: 'flex', backgroundColor: 'rgb(240, 240, 255)' });
+
+    assert.dom(`.${titleClass}`).exists();
+    assert
+      .dom(`.${titleClass}`)
+      .hasStyle({ fontSize: '18px', fontWeight: '700', color: 'rgb(10, 20, 200)' });
+
+    assert.dom(`.${bodyClass}`).exists();
+    assert
+      .dom(`.${bodyClass}`)
+      .hasStyle({ fontSize: '14px', fontWeight: '400', color: 'rgb(50, 50, 50)' });
+  });
+
+  test('@use from an external partial applies mixins and scopes classes', async function (assert) {
+    await render(ScopedScssAtUse);
+
+    const scope = 'vite-app/components/in-app/scoped-scss';
+
+    const btnClass = scopedClass('btn-primary', scope);
+    const srClass = scopedClass('sr-label', scope);
+
+    assert.dom(`.${btnClass}`).exists();
+    assert.dom(`.${btnClass}`).hasStyle({
+      display: 'inline-flex',
+      backgroundColor: 'rgb(0, 112, 240)',
+      color: 'rgb(255, 255, 255)',
+    });
+
+    // visually-hidden mixin: element is in the DOM but not visible
+    assert.dom(`.${srClass}`).exists();
+    assert.dom(`.${srClass}`).hasStyle({
+      position: 'absolute',
+      width: '1px',
+      height: '1px',
+    });
+  });
+});

--- a/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
+++ b/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
@@ -6,6 +6,7 @@ import {
   ScopedScss,
   ScopedScssMixins,
   ScopedScssAtUse,
+  ScopedBEM,
 } from 'vite-app/components/in-app/scoped-scss';
 
 import { scopedClass } from 'ember-scoped-css/test-support';
@@ -75,5 +76,17 @@ module('[In App] scoped scss', function (hooks) {
       width: '1px',
       height: '1px',
     });
+  });
+
+  test('supports BEM classes correctly', async function (assert) {
+    await render(ScopedBEM);
+
+    assert
+      .dom('p')
+      .hasClass(
+        scopedClass('hi--modifier', 'vite-app/components/in-app/scoped-scss')
+      );
+
+    assert.dom('p').hasStyle({ color: 'rgb(0, 0, 200)', fontWeight: '700' });
   });
 });

--- a/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
+++ b/test-apps/vite-app/tests/in-app/scoped-scss-test.gjs
@@ -19,7 +19,7 @@ module('[In App] scoped scss', function (hooks) {
     assert
       .dom('p')
       .hasClass(
-        scopedClass('scss-hi', 'vite-app/components/in-app/scoped-scss'),
+        scopedClass('scss-hi', 'vite-app/components/in-app/scoped-scss')
       );
     assert.dom('p').hasStyle({ color: 'rgb(200, 0, 100)' });
   });
@@ -39,14 +39,18 @@ module('[In App] scoped scss', function (hooks) {
       .hasStyle({ display: 'flex', backgroundColor: 'rgb(240, 240, 255)' });
 
     assert.dom(`.${titleClass}`).exists();
-    assert
-      .dom(`.${titleClass}`)
-      .hasStyle({ fontSize: '18px', fontWeight: '700', color: 'rgb(10, 20, 200)' });
+    assert.dom(`.${titleClass}`).hasStyle({
+      fontSize: '18px',
+      fontWeight: '700',
+      color: 'rgb(10, 20, 200)',
+    });
 
     assert.dom(`.${bodyClass}`).exists();
-    assert
-      .dom(`.${bodyClass}`)
-      .hasStyle({ fontSize: '14px', fontWeight: '400', color: 'rgb(50, 50, 50)' });
+    assert.dom(`.${bodyClass}`).hasStyle({
+      fontSize: '14px',
+      fontWeight: '400',
+      color: 'rgb(50, 50, 50)',
+    });
   });
 
   test('@use from an external partial applies mixins and scopes classes', async function (assert) {


### PR DESCRIPTION
I let claude have a bash at this to get the ball rolling.

---

## Add CSS preprocessor support (SCSS/Sass/Less/Stylus)
Enables `<style scoped lang="scss">` (and other preprocessor languages) in Glimmer component templates. Preprocessing is handled by Vite's built-in `preprocessCSS` API, so **no new mandatory dependencies** are introduced — you just need the preprocessor already installed in your app (e.g. `sass`).

**Vite only.** Rollup and webpack builds will throw a clear error if `lang=` is used.

### How it works
**Babel stage (class/tag extraction)**
`getCSSContentInfo` now accepts an optional `lang` parameter. When `lang` is `scss` or `sass`, it parses with `postcss-scss` as a tolerant syntax parser — this lets the Glimmer AST plugin extract scoped class/tag names from SCSS without crashing on nesting, `&` selectors, or variables. The hash is still computed from the raw pre-compiled source.

**Vite stage (actual compilation)**
Both `unplugin-inline` and `unplugin-colocated` capture Vite's `preprocessCSS` function during `configResolved` (resolved via `createRequire` from the app root, so the correct Vite installation is always used). Their `load` hooks are now async and call `preprocessCSS` before passing the result to `rewriteCss`.
For inline styles, the `lang` value is encoded as a `&lang=<value>` query parameter on the virtual module URL, so it survives the round-trip from Babel to Vite's plugin system.

**`<style scoped inline lang="...">` downgrade**
Preprocessing is async and cannot run at Babel-time. If `inline` and `lang` are both present, the plugin:
1. Logs a warning explaining the limitation
2. Removes the `<style>` tag from the template (same as non-inline)
3. Emits a virtual CSS module import that gets preprocessed at Vite load time

### Changes

- **`ember-scoped-css/package.json`** — adds `postcss-scss` as a dependency (used as a tolerant parser at Babel-time, not a compiler)
- **`src/lib/css/utils.js`** — `getCSSContentInfo(css, lang?)` uses `postcss-scss` syntax when `lang` is `scss`/`sass`
- **`src/lib/request.js`** — `inline.create` accepts an optional `lang` param encoded into the virtual URL; `inline.decode` returns it
- **`src/build/template-plugin.js`** — reads `lang` attribute, passes it through to `getCSSContentInfo` and `request.inline.create`; handles `inline + lang` downgrade
- **`src/build/unplugin-inline.js`** — `configResolved` captures `preprocessCSS`; `load` is now async and calls it when `lang` is set
- **`src/build/unplugin-colocated.js`** — same pattern; `vite.load` preprocesses colocated files whose extension is in `{.scss, .sass, .less, .styl, .stylus}`

### Tests

**Unit (`template-plugin.test.ts`)**
- `<style scoped lang="scss">` — style tag removed, virtual import emitted with `&lang=scss`
- `<style scoped inline lang="scss">` — same output + warning logged (downgrade behaviour)

**Unit (`utils.js`)**
- `getCSSContentInfo` with SCSS nesting parses without throwing for `lang=scss` and `lang=sass`

**Integration (`test-apps/vite-app`)**
- Variables, nesting, `&` selectors
- Inline `@mixin` / `@include` with arguments
- `@use './mixins' as m` — imports a colocated `_mixins.scss` partial and calls its mixins; validates that class scoping and compiled styles are both correct