### PR TITLE
Add ember-scoped-css/types declaration entrypoint for tsconfig compilerOptions.types

### DIFF
--- a/ember-scoped-css/README.md
+++ b/ember-scoped-css/README.md
@@ -194,7 +194,25 @@ Requires
 - @glint/template 1.7.0 or higher
 - @glint/tsserver-plugin 2.0.5 or higher
 
-In `types/index.d.ts` (or similar for apps) or `unpublished-development-types/index.d.ts` (for libraries), we'll declaration merge merge the known attributes for the `<style>` tag:
+Add `ember-scoped-css/types` to the [`types`](https://www.typescriptlang.org/tsconfig#types) array in your `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "types": ["ember-scoped-css/types"]
+  }
+}
+```
+
+If your project doesn't use `compilerOptions.types` (note that specifying it disables automatic inclusion of `@types/*` packages), you can instead import the declarations from a type-declaration file that is included in your project — `types/index.d.ts` (or similar for apps) or `unpublished-development-types/index.d.ts` (for libraries):
+
+```ts
+import 'ember-scoped-css/types';
+```
+
+<details><summary>What <code>ember-scoped-css/types</code> provides</summary>
+
+It declaration-merges the known attributes for the `<style>` tag:
 
 ```ts
 import '@glint/template';
@@ -206,6 +224,8 @@ declare global {
   }
 }
 ```
+
+</details>
 
 ### template-lint
 

--- a/ember-scoped-css/eslint.config.mjs
+++ b/ember-scoped-css/eslint.config.mjs
@@ -8,6 +8,7 @@ export default [
       'declarations',
       'dist',
       'template-registry.d.ts',
+      'types.d.ts',
       'vitest.config.mts',
     ],
   },

--- a/ember-scoped-css/package.json
+++ b/ember-scoped-css/package.json
@@ -19,7 +19,8 @@
     "dist",
     "declarations",
     "addon-main.cjs",
-    "template-registry.d.ts"
+    "template-registry.d.ts",
+    "types.d.ts"
   ],
   "exports": {
     ".": {
@@ -40,6 +41,10 @@
     },
     "./template-registry": {
       "types": "./template-registry.d.ts",
+      "default": "./src/noop.js"
+    },
+    "./types": {
+      "types": "./types.d.ts",
       "default": "./src/noop.js"
     },
     "./test-support": {

--- a/ember-scoped-css/types.d.ts
+++ b/ember-scoped-css/types.d.ts
@@ -1,0 +1,30 @@
+/**
+ * This declaration file teaches TypeScript (via Glint) about the special
+ * attributes that ember-scoped-css adds to the `<style>` element,
+ * so that `<style scoped>` and `<style inline>` type-check.
+ *
+ * Add it to your tsconfig.json:
+ *
+ * ```jsonc
+ * {
+ *   "compilerOptions": {
+ *     "types": ["ember-scoped-css/types"]
+ *   }
+ * }
+ * ```
+ *
+ * or, if you don't use `compilerOptions.types`, import it from a
+ * type-declaration file that is included in your project:
+ *
+ * ```ts
+ * import 'ember-scoped-css/types';
+ * ```
+ */
+import '@glint/template';
+
+declare global {
+  interface HTMLStyleElementAttributes {
+    scoped: '';
+    inline: '';
+  }
+}

--- a/test-apps/v2-addon-ts-glint-2/tsconfig.json
+++ b/test-apps/v2-addon-ts-glint-2/tsconfig.json
@@ -5,19 +5,15 @@
  */
 {
   "extends": "@ember/app-tsconfig",
-  "include": [
-    "src/**/*",
-    "tests/**/*",
-    "unpublished-development-types/**/*",
-    "demo-app/**/*"
-  ],
+  "include": ["src/**/*", "tests/**/*", "demo-app/**/*"],
   "compilerOptions": {
     "rootDir": ".",
     "types": [
       "ember-source/types",
       "vite/client",
       "@embroider/core/virtual",
-      "@glint/ember-tsc/types"
+      "@glint/ember-tsc/types",
+      "ember-scoped-css/types"
     ]
   }
 }

--- a/test-apps/v2-addon-ts-glint-2/tsconfig.publish.json
+++ b/test-apps/v2-addon-ts-glint-2/tsconfig.publish.json
@@ -5,7 +5,7 @@
  */
 {
   "extends": "@ember/library-tsconfig",
-  "include": ["./src/**/*", "./unpublished-development-types/**/*"],
+  "include": ["./src/**/*"],
   "compilerOptions": {
     "allowJs": true,
     "declarationDir": "declarations",
@@ -22,6 +22,10 @@
     */
     "rootDir": "./src",
 
-    "types": ["ember-source/types", "@glint/ember-tsc/types"]
+    "types": [
+      "ember-source/types",
+      "@glint/ember-tsc/types",
+      "ember-scoped-css/types"
+    ]
   }
 }

--- a/test-apps/v2-addon-ts-glint-2/unpublished-development-types/index.d.ts
+++ b/test-apps/v2-addon-ts-glint-2/unpublished-development-types/index.d.ts
@@ -1,8 +1,0 @@
-import '@glint/template';
-
-declare global {
-  interface HTMLStyleElementAttributes {
-    scoped: '';
-    inline: '';
-  }
-}

--- a/test-apps/v2-addon-ts-with-cjs-babel/tsconfig.json
+++ b/test-apps/v2-addon-ts-with-cjs-babel/tsconfig.json
@@ -5,6 +5,7 @@
     "environment": ["ember-loose", "ember-template-imports"]
   },
   "compilerOptions": {
+    "types": ["ember-scoped-css/types"],
     "target": "ESNext",
     "allowJs": true,
     "skipLibCheck": true,

--- a/test-apps/v2-addon-ts-with-cjs-babel/unpublished-development-types/index.d.ts
+++ b/test-apps/v2-addon-ts-with-cjs-babel/unpublished-development-types/index.d.ts
@@ -17,10 +17,3 @@ declare module '@glint/environment-ember-loose/registry' {
     'AtClass::HasAtClass': typeof HasAtClass;
   }
 }
-
-declare global {
-  interface HTMLStyleElementAttributes {
-    scoped: '';
-    inline: '';
-  }
-}

--- a/test-apps/v2-addon-ts/tsconfig.json
+++ b/test-apps/v2-addon-ts/tsconfig.json
@@ -5,6 +5,7 @@
     "environment": ["ember-loose", "ember-template-imports"]
   },
   "compilerOptions": {
+    "types": ["ember-scoped-css/types"],
     "target": "ESNext",
     "allowJs": true,
     "skipLibCheck": true,

--- a/test-apps/v2-addon-ts/unpublished-development-types/index.d.ts
+++ b/test-apps/v2-addon-ts/unpublished-development-types/index.d.ts
@@ -17,10 +17,3 @@ declare module '@glint/environment-ember-loose/registry' {
     'AtClass::HasAtClass': typeof HasAtClass;
   }
 }
-
-declare global {
-  interface HTMLStyleElementAttributes {
-    scoped: '';
-    inline: '';
-  }
-}


### PR DESCRIPTION
## Summary

Adds a new publishable type-declaration entrypoint, `ember-scoped-css/types`, containing the `HTMLStyleElementAttributes` global augmentation (`scoped`, `inline`) that the README's TypeScript section previously asked consumers to hand-copy into their own `.d.ts` files.

Consumers can now opt in via `tsconfig.json`:

```jsonc
{
  "compilerOptions": {
    "types": ["ember-scoped-css/types"]
  }
}
```

or, for projects that don't manage a `compilerOptions.types` array, via a side-effect import from any included declaration file:

```ts
import 'ember-scoped-css/types';
```

## Changes

- New `ember-scoped-css/types.d.ts`, shipped at the package root (like `template-registry.d.ts`) so it resolves under classic node resolution as well as through the new `./types` entry in `package.json#exports` (`files` updated accordingly).
- README's TypeScript section now documents the `compilerOptions.types` technique (with the side-effect-import alternative), keeping the underlying `declare global` block in a collapsible "what this provides" details block.
- The monorepo's TS test-apps now consume the new entrypoint instead of hand-written `declare global` blocks:
  - `v2-addon-ts-glint-2`: added to the `types` arrays of both `tsconfig.json` and `tsconfig.publish.json`; its `unpublished-development-types/index.d.ts` (which contained only the augmentation) is deleted.
  - `v2-addon-ts` / `v2-addon-ts-with-cjs-babel`: `types` array added to their tsconfigs; the `declare global` blocks removed from their `unpublished-development-types/index.d.ts`.

## Verification

- `pnpm build` at the repo root passes (including `v2-addon-ts-glint-2`'s `ember-tsc --declaration` publish build, which fails with `TS2353: 'scoped' does not exist` when the entry is absent — confirming the entrypoint is load-bearing).
- `pnpm lint` (including `lint:types` — glint 1 in `v2-addon-ts`/`v2-addon-ts-with-cjs-babel`/`vite-app-with-compat-pods`, `ember-tsc --noEmit` in `v2-addon-ts-glint-2`) passes in all TS test-apps.
- `vitest` in the `ember-scoped-css` package: 112 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
