### PR TITLE
Rewrite class names in unquoted class attributes

### DIFF
--- a/ember-scoped-css/src/build/template-plugin.js
+++ b/ember-scoped-css/src/build/template-plugin.js
@@ -112,7 +112,6 @@ export function createPlugin(config) {
       tags: scopedTags,
       attributes: scopedAttributes,
       postfix,
-      strictMode: env.strictMode,
     });
 
     return {

--- a/ember-scoped-css/src/build/template-plugin.js
+++ b/ember-scoped-css/src/build/template-plugin.js
@@ -112,6 +112,7 @@ export function createPlugin(config) {
       tags: scopedTags,
       attributes: scopedAttributes,
       postfix,
+      strictMode: env.strictMode,
     });
 
     return {
@@ -171,43 +172,48 @@ export function createPlugin(config) {
         AttrNode(...args) {
           return visitors.AttrNode(...args);
         },
-        ElementNode(node, walker) {
-          // class attribute handling
-          visitors.ElementNode(node, walker);
+        ElementNode: {
+          enter(node, walker) {
+            // class attribute handling, and tracking the element's block params
+            visitors.ElementNode.enter(node, walker);
 
-          if (hasScopedAttribute(node)) {
-            if (walker.parent?.node.type !== 'Template') {
-              throw new Error(
-                '<style scoped> tags must be at the root of the template, they cannot be nested',
-              );
+            if (hasScopedAttribute(node)) {
+              if (walker.parent?.node.type !== 'Template') {
+                throw new Error(
+                  '<style scoped> tags must be at the root of the template, they cannot be nested',
+                );
+              }
+
+              if (hasInlineAttributeWithoutLang(node)) {
+                let text = textContent(node);
+                let scopedText = rewriteCss(
+                  text,
+                  postfix,
+                  localCssPath,
+                  config.layerName,
+                );
+
+                /**
+                 * Traverse this and allow interpolation
+                 */
+                node.children = [env.syntax.builders.text(scopedText)];
+
+                return;
+              }
+
+              // Returning null removes the node
+              return null;
             }
 
             if (hasInlineAttributeWithoutLang(node)) {
-              let text = textContent(node);
-              let scopedText = rewriteCss(
-                text,
-                postfix,
-                localCssPath,
-                config.layerName,
+              throw new Error(
+                `<style inline> is not valid. Please add the scoped attribute: <style scoped inline>`,
               );
-
-              /**
-               * Traverse this and allow interpolation
-               */
-              node.children = [env.syntax.builders.text(scopedText)];
-
-              return;
             }
-
-            // Returning null removes the node
-            return null;
-          }
-
-          if (hasInlineAttributeWithoutLang(node)) {
-            throw new Error(
-              `<style inline> is not valid. Please add the scoped attribute: <style scoped inline>`,
-            );
-          }
+          },
+          exit(...args) {
+            return visitors.ElementNode.exit(...args);
+          },
         },
         MustacheStatement(...args) {
           return visitors.MustacheStatement(...args);

--- a/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
+++ b/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
@@ -56,9 +56,9 @@ describe('class attribute values', () => {
 
     it('reaches literals nested in a class-building subexpression', () => {
       expect(
-        rewrite('<div class={{if x (concat "a" "-suffix") "b"}}></div>'),
+        rewrite('<div class={{if x (concat "a" " " "b") "b"}}></div>'),
       ).to.equal(
-        '<div class={{if x (concat "a_pfx" "-suffix") "b_pfx"}}></div>',
+        '<div class={{if x (concat "a_pfx" " " "b_pfx") "b_pfx"}}></div>',
       );
     });
 
@@ -131,12 +131,24 @@ describe('class attribute values', () => {
     });
 
     it('leaves a comparand alone inside a class-building helper', () => {
+      // "a" fuses with whichever branch wins, so none of these is a class name.
       expect(
         rewrite(
           '<div class={{concat "a" (if (eq this.x "b") "-on" "-off")}}></div>',
         ),
       ).to.equal(
-        '<div class={{concat "a_pfx" (if (eq this.x "b") "-on" "-off")}}></div>',
+        '<div class={{concat "a" (if (eq this.x "b") "-on" "-off")}}></div>',
+      );
+    });
+
+    it('reaches into a subexpression a boundary separates', () => {
+      // The space makes the branches whole class names rather than fragments.
+      expect(
+        rewrite(
+          '<div class={{concat "a " (if this.x "b" "global-thing")}}></div>',
+        ),
+      ).to.equal(
+        '<div class={{concat "a_pfx " (if this.x "b_pfx" "global-thing")}}></div>',
       );
     });
 
@@ -146,6 +158,129 @@ describe('class attribute values', () => {
       expect(rewrite('<div class={{someHelper "a"}}></div>')).to.equal(
         '<div class={{someHelper "a"}}></div>',
       );
+    });
+  });
+
+  /**
+   * concat joins its params into one string, so a literal is only a class name
+   * of its own when a boundary separates it from its neighbours. Postfixing a
+   * fragment would bury the postfix in the middle of the resulting class, where
+   * it matches no selector the CSS rewrite produces.
+   */
+  describe('concat fuses its params', () => {
+    /** `a-suffix` is a class in the CSS in its own right. */
+    function rewriteWithSuffixClass(hbs) {
+      return rewriteHbs(
+        hbs,
+        new Set(['a', 'b', 'a-suffix']),
+        new Set(),
+        postfix,
+      );
+    }
+
+    it('folds fused literals so the postfix lands at the end', () => {
+      expect(
+        rewriteWithSuffixClass('<div class={{concat "a" "-suffix"}}></div>'),
+      ).to.equal('<div class={{concat "a-suffix_pfx"}}></div>');
+    });
+
+    it('folds fused literals inside a branch too', () => {
+      expect(
+        rewriteWithSuffixClass(
+          '<div class={{if x (concat "a" "-suffix") "b"}}></div>',
+        ),
+      ).to.equal('<div class={{if x (concat "a-suffix_pfx") "b_pfx"}}></div>');
+    });
+
+    it('leaves fused literals alone when the fold is not a class', () => {
+      // Renaming "a" here would emit a_pfx-suffix, which matches nothing.
+      expect(rewrite('<div class={{concat "a" "-suffix"}}></div>')).to.equal(
+        '<div class={{concat "a" "-suffix"}}></div>',
+      );
+    });
+
+    it('leaves a literal that fuses with a dynamic value alone', () => {
+      expect(rewrite('<div class={{concat "a" this.x}}></div>')).to.equal(
+        '<div class={{concat "a" this.x}}></div>',
+      );
+    });
+
+    it('renames a literal a boundary separates from a dynamic value', () => {
+      expect(rewrite('<div class={{concat "a " this.x}}></div>')).to.equal(
+        '<div class={{concat "a_pfx " this.x}}></div>',
+      );
+    });
+
+    it('renames a literal that begins at a boundary', () => {
+      expect(rewrite('<div class={{concat this.x " b"}}></div>')).to.equal(
+        '<div class={{concat this.x " b_pfx"}}></div>',
+      );
+    });
+  });
+
+  describe('a shadowed helper is not our helper', () => {
+    it('skips a concat shadowed by a block param', () => {
+      expect(
+        rewrite(
+          '{{#let this.x as |concat|}}<div class={{concat "a" " " "b"}}></div>{{/let}}',
+        ),
+      ).to.equal(
+        '{{#let this.x as |concat|}}<div class={{concat "a" " " "b"}}></div>{{/let}}',
+      );
+    });
+
+    it('skips a helper shadowed by an element block param', () => {
+      expect(
+        rewrite(
+          '<Foo as |unless|><div class={{unless y "a" "b"}}></div></Foo>',
+        ),
+      ).to.equal(
+        '<Foo as |unless|><div class={{unless y "a" "b"}}></div></Foo>',
+      );
+    });
+
+    it('skips if when it is a block param', () => {
+      expect(
+        rewrite(
+          '{{#each xs as |if|}}<div class={{if y "a" "b"}}></div>{{/each}}',
+        ),
+      ).to.equal(
+        '{{#each xs as |if|}}<div class={{if y "a" "b"}}></div>{{/each}}',
+      );
+    });
+
+    it('resumes renaming once the block param is out of scope', () => {
+      expect(
+        rewrite(
+          '<Foo as |concat|></Foo><div class={{concat "a" " " "b"}}></div>',
+        ),
+      ).to.equal(
+        '<Foo as |concat|></Foo><div class={{concat "a_pfx" " " "b_pfx"}}></div>',
+      );
+    });
+  });
+
+  describe('strict mode', () => {
+    function rewriteStrict(hbs) {
+      return rewriteHbs(hbs, classes, new Set(), postfix, new Set(), true);
+    }
+
+    it('trusts if, which needs no import', () => {
+      expect(rewriteStrict('<div class={{if x "a" "b"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('trusts unless, which needs no import', () => {
+      expect(rewriteStrict('<div class={{unless x "a" "b"}}></div>')).to.equal(
+        '<div class={{unless x "a_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('does not trust concat, which must be imported from somewhere', () => {
+      expect(
+        rewriteStrict('<div class={{concat "a" " " "b"}}></div>'),
+      ).to.equal('<div class={{concat "a" " " "b"}}></div>');
     });
   });
 

--- a/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
+++ b/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
@@ -260,30 +260,6 @@ describe('class attribute values', () => {
     });
   });
 
-  describe('strict mode', () => {
-    function rewriteStrict(hbs) {
-      return rewriteHbs(hbs, classes, new Set(), postfix, new Set(), true);
-    }
-
-    it('trusts if, which needs no import', () => {
-      expect(rewriteStrict('<div class={{if x "a" "b"}}></div>')).to.equal(
-        '<div class={{if x "a_pfx" "b_pfx"}}></div>',
-      );
-    });
-
-    it('trusts unless, which needs no import', () => {
-      expect(rewriteStrict('<div class={{unless x "a" "b"}}></div>')).to.equal(
-        '<div class={{unless x "a_pfx" "b_pfx"}}></div>',
-      );
-    });
-
-    it('does not trust concat, which must be imported from somewhere', () => {
-      expect(
-        rewriteStrict('<div class={{concat "a" " " "b"}}></div>'),
-      ).to.equal('<div class={{concat "a" " " "b"}}></div>');
-    });
-  });
-
   describe('the scopedClass helper still collapses to a text node', () => {
     it('renames unconditionally, without a CSS lookup', () => {
       expect(

--- a/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
+++ b/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import rewriteHbs from './rewriteHbs.js';
+
+const postfix = 'pfx';
+
+/**
+ * `a` and `b` are in the co-located CSS; `global-thing` deliberately is not, so
+ * every test can distinguish "renamed" from "left alone for a global class".
+ */
+const classes = new Set(['a', 'b']);
+
+function rewrite(hbs) {
+  return rewriteHbs(hbs, classes, new Set(), postfix);
+}
+
+describe('class attribute values', () => {
+  describe('quoted (ConcatStatement)', () => {
+    it('renames literals in a mustache', () => {
+      expect(rewrite(`<div class="{{if x 'a' 'b'}}"></div>`)).to.equal(
+        `<div class="{{if x 'a_pfx' 'b_pfx'}}"></div>`,
+      );
+    });
+
+    it('renames both the text part and the mustache literals', () => {
+      expect(rewrite(`<div class="a {{if x 'b'}}"></div>`)).to.equal(
+        `<div class="a_pfx {{if x 'b_pfx'}}"></div>`,
+      );
+    });
+  });
+
+  describe('unquoted (MustacheStatement)', () => {
+    it('renames literals in a mustache', () => {
+      expect(rewrite('<div class={{if x "a" "b"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('leaves a class that is not in the CSS alone', () => {
+      expect(rewrite('<div class={{if x "global-thing"}}></div>')).to.equal(
+        '<div class={{if x "global-thing"}}></div>',
+      );
+    });
+
+    it('renames only the literals that are in the CSS', () => {
+      expect(rewrite('<div class={{if x "a" "global-thing"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx" "global-thing"}}></div>',
+      );
+    });
+
+    it('reaches literals in any helper, not just if', () => {
+      expect(rewrite('<div class={{concat "a" " " "b"}}></div>')).to.equal(
+        '<div class={{concat "a_pfx" " " "b_pfx"}}></div>',
+      );
+    });
+
+    it('reaches literals nested in a subexpression', () => {
+      expect(
+        rewrite('<div class={{if x (concat "a" "-suffix") "b"}}></div>'),
+      ).to.equal(
+        '<div class={{if x (concat "a_pfx" "-suffix") "b_pfx"}}></div>',
+      );
+    });
+
+    it('renames every class in a multi-class literal', () => {
+      expect(rewrite('<div class={{if x "a b" "b"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx b_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('leaves a path expression alone', () => {
+      // A path resolves at runtime, so there is no literal to rename.
+      expect(rewrite('<div class={{this.fooClass}}></div>')).to.equal(
+        '<div class={{this.fooClass}}></div>',
+      );
+    });
+
+    it('renames on a component invocation', () => {
+      expect(rewrite('<Foo class={{if x "a" "b"}} />')).to.equal(
+        '<Foo class={{if x "a_pfx" "b_pfx"}} />',
+      );
+    });
+
+    it('does not rename an already-postfixed class', () => {
+      expect(rewrite('<div class={{if x "a_pfx"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx"}}></div>',
+      );
+    });
+
+    it('only touches the class attribute', () => {
+      expect(rewrite('<div data-x={{if x "a" "b"}}></div>')).to.equal(
+        '<div data-x={{if x "a" "b"}}></div>',
+      );
+    });
+  });
+
+  describe('the scopedClass helper still collapses to a text node', () => {
+    it('renames unconditionally, without a CSS lookup', () => {
+      expect(
+        rewrite('<div class={{scopedClass "global-thing"}}></div>'),
+      ).to.equal('<div class="global-thing_pfx"></div>');
+    });
+
+    it('does not double-postfix a class that is in the CSS', () => {
+      expect(rewrite('<div class={{scopedClass "a"}}></div>')).to.equal(
+        '<div class="a_pfx"></div>',
+      );
+    });
+
+    it('does not double-postfix the legacy hbs global either', () => {
+      expect(rewrite('<div class={{scoped-class "a"}}></div>')).to.equal(
+        '<div class="a_pfx"></div>',
+      );
+    });
+  });
+
+  describe('an element that is also scoped by its tag', () => {
+    function rewriteScopedDiv(hbs) {
+      return rewriteHbs(hbs, classes, new Set(['div']), postfix);
+    }
+
+    it('renames literals and appends the postfix class', () => {
+      expect(rewriteScopedDiv('<div class={{if x "a" "b"}}></div>')).to.equal(
+        '<div class="{{if x "a_pfx" "b_pfx"}} pfx"></div>',
+      );
+    });
+
+    it('appends the postfix class to a path expression', () => {
+      expect(rewriteScopedDiv('<div class={{this.fooClass}}></div>')).to.equal(
+        '<div class="{{this.fooClass}} pfx"></div>',
+      );
+    });
+  });
+});

--- a/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
+++ b/ember-scoped-css/src/lib/rewriteHbs.classes.test.ts
@@ -54,11 +54,23 @@ describe('class attribute values', () => {
       );
     });
 
-    it('reaches literals nested in a subexpression', () => {
+    it('reaches literals nested in a class-building subexpression', () => {
       expect(
         rewrite('<div class={{if x (concat "a" "-suffix") "b"}}></div>'),
       ).to.equal(
         '<div class={{if x (concat "a_pfx" "-suffix") "b_pfx"}}></div>',
+      );
+    });
+
+    it('renames the branches of unless', () => {
+      expect(rewrite('<div class={{unless x "a" "b"}}></div>')).to.equal(
+        '<div class={{unless x "a_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('renames the single branch of a two-param if', () => {
+      expect(rewrite('<div class={{if x "a"}}></div>')).to.equal(
+        '<div class={{if x "a_pfx"}}></div>',
       );
     });
 
@@ -90,6 +102,49 @@ describe('class attribute values', () => {
     it('only touches the class attribute', () => {
       expect(rewrite('<div data-x={{if x "a" "b"}}></div>')).to.equal(
         '<div data-x={{if x "a" "b"}}></div>',
+      );
+    });
+  });
+
+  describe('literals that are not class names', () => {
+    it('leaves the arguments of a helper in the condition alone', () => {
+      expect(
+        rewrite('<div class={{if (checkAlphabet "a" "b") "a" "b"}}></div>'),
+      ).to.equal(
+        '<div class={{if (checkAlphabet "a" "b") "a_pfx" "b_pfx"}}></div>',
+      );
+    });
+
+    it('leaves the arguments of a condition alone in a quoted value too', () => {
+      expect(
+        rewrite(`<div class="{{if (checkAlphabet 'a' 'b') 'a' 'b'}}"></div>`),
+      ).to.equal(
+        `<div class="{{if (checkAlphabet 'a' 'b') 'a_pfx' 'b_pfx'}}"></div>`,
+      );
+    });
+
+    it('leaves a comparand alone', () => {
+      // Postfixing it would stop the comparison ever matching this.mode.
+      expect(
+        rewrite('<div class={{if (eq this.mode "a") "a" "b"}}></div>'),
+      ).to.equal('<div class={{if (eq this.mode "a") "a_pfx" "b_pfx"}}></div>');
+    });
+
+    it('leaves a comparand alone inside a class-building helper', () => {
+      expect(
+        rewrite(
+          '<div class={{concat "a" (if (eq this.x "b") "-on" "-off")}}></div>',
+        ),
+      ).to.equal(
+        '<div class={{concat "a_pfx" (if (eq this.x "b") "-on" "-off")}}></div>',
+      );
+    });
+
+    it('leaves the arguments of an opaque helper alone', () => {
+      // The helper may well return a class name, but what it does with its
+      // arguments is unknown. {{scopedClass "a"}} renames a literal here.
+      expect(rewrite('<div class={{someHelper "a"}}></div>')).to.equal(
+        '<div class={{someHelper "a"}}></div>',
       );
     });
   });

--- a/ember-scoped-css/src/lib/rewriteHbs.js
+++ b/ember-scoped-css/src/lib/rewriteHbs.js
@@ -30,6 +30,23 @@ function elementHasScopedAttribute(node, attributes) {
   );
 }
 
+/**
+ * Helpers whose result is assembled from their own params, mapped to the params
+ * that land in the result. `concat` joins all of them; `if` and `unless` return
+ * one of their branches, so the condition at index 0 is excluded -- it decides
+ * which branch wins rather than contributing to the class string.
+ *
+ * Any helper absent from this map is opaque: it may return a class name, but
+ * what it does with its arguments is unknown, so those arguments are left
+ * alone. `{{scopedClass "..."}}` is the way to rename a literal such a helper
+ * receives.
+ */
+const CLASS_BUILDING_HELPERS = new Map([
+  ['concat', (params) => params],
+  ['if', (params) => params.slice(1)],
+  ['unless', (params) => params.slice(1)],
+]);
+
 export function templatePlugin({ classes, tags, attributes, postfix }) {
   let stack = [];
   // scoped-class is a global we allow in hbs
@@ -43,18 +60,38 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
   }
 
   /**
-   * Only string literals are reachable: a path expression such as
-   * `{{this.fooClass}}` resolves at runtime, so it carries no class name to
-   * rename at build time.
+   * Rename the string literals whose value reaches the class attribute.
+   *
+   * A literal qualifies only if every helper between it and the attribute
+   * builds its result out of that literal, so the walk descends through the
+   * params listed in CLASS_BUILDING_HELPERS and stops everywhere else. A
+   * literal that some other helper merely reads is data: postfixing it would
+   * change what that helper computes, as in `{{if (eq this.mode "a") "a" "b"}}`
+   * where only the two branches are class names.
+   *
+   * A path expression such as `{{this.fooClass}}` resolves at runtime, so it
+   * carries no class name to rename at build time.
    */
-  function renameLiteralClasses(mustache) {
-    recast.traverse(mustache, {
-      StringLiteral(node) {
-        const renamedClass = renameClass(node.value, postfix, classes);
+  function renameLiteralClasses(node) {
+    if (node.type === 'StringLiteral') {
+      const renamedClass = renameClass(node.value, postfix, classes);
 
-        node.value = renamedClass;
-      },
-    });
+      node.value = renamedClass;
+
+      return;
+    }
+
+    if (node.type !== 'MustacheStatement' && node.type !== 'SubExpression') {
+      return;
+    }
+
+    const classParamsOf = CLASS_BUILDING_HELPERS.get(getValue(node.path));
+
+    if (!classParamsOf) return;
+
+    for (let param of classParamsOf(node.params ?? [])) {
+      renameLiteralClasses(param);
+    }
   }
 
   return {

--- a/ember-scoped-css/src/lib/rewriteHbs.js
+++ b/ember-scoped-css/src/lib/rewriteHbs.js
@@ -31,23 +31,66 @@ function elementHasScopedAttribute(node, attributes) {
 }
 
 /**
- * Helpers whose result is assembled from their own params, mapped to the params
- * that land in the result. `concat` joins all of them; `if` and `unless` return
- * one of their branches, so the condition at index 0 is excluded -- it decides
- * which branch wins rather than contributing to the class string.
+ * Helpers whose result is assembled from their own params. `concat` joins all
+ * of them; `if` and `unless` return one of their branches, so their condition
+ * at index 0 is excluded -- it decides which branch wins rather than
+ * contributing to the class string.
  *
- * Any helper absent from this map is opaque: it may return a class name, but
- * what it does with its arguments is unknown, so those arguments are left
- * alone. `{{scopedClass "..."}}` is the way to rename a literal such a helper
- * receives.
+ * Any other helper is opaque: it may return a class name, but what it does with
+ * its arguments is unknown, so those arguments are left alone.
+ * `{{scopedClass "..."}}` is the way to rename a literal such a helper receives.
  */
-const CLASS_BUILDING_HELPERS = new Map([
-  ['concat', (params) => params],
-  ['if', (params) => params.slice(1)],
-  ['unless', (params) => params.slice(1)],
-]);
+const CLASS_BUILDING_HELPERS = new Set(['concat', 'if', 'unless']);
 
-export function templatePlugin({ classes, tags, attributes, postfix }) {
+/**
+ * Of the above, the ones a strict-mode template gets for free. `concat` is not
+ * among them: strict mode requires it to be imported, and which module it came
+ * from is not visible from the template, so there it could be any function.
+ */
+const KEYWORDS = new Set(['if', 'unless']);
+
+function endsAtClassBoundary(value) {
+  return /\s$/.test(value);
+}
+
+function startsAtClassBoundary(value) {
+  return /^\s/.test(value);
+}
+
+/**
+ * Whether the literal at `index` is a whole class name rather than a fragment
+ * that `concat` fuses onto a neighbour. In `{{concat "a" "-suffix"}}` the "a"
+ * is a fragment: the result is one class, `a-suffix`, so postfixing "a" on its
+ * own would bury the postfix in the middle of it.
+ */
+function isWholeClassName(params, index) {
+  const param = params[index];
+  // A param whose value is only known at runtime is bounded by its neighbours
+  // alone, so it contributes no boundary of its own.
+  const value = param.type === 'StringLiteral' ? param.value : '';
+  const previous = params[index - 1];
+  const next = params[index + 1];
+
+  const boundedLeft =
+    startsAtClassBoundary(value) ||
+    index === 0 ||
+    (previous.type === 'StringLiteral' && endsAtClassBoundary(previous.value));
+
+  const boundedRight =
+    endsAtClassBoundary(value) ||
+    index === params.length - 1 ||
+    (next.type === 'StringLiteral' && startsAtClassBoundary(next.value));
+
+  return boundedLeft && boundedRight;
+}
+
+export function templatePlugin({
+  classes,
+  tags,
+  attributes,
+  postfix,
+  strictMode = false,
+}) {
   let stack = [];
   // scoped-class is a global we allow in hbs
   // scopedClass is importable, and we'll error if someone tries to rename it
@@ -60,16 +103,77 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
   }
 
   /**
+   * Block params introduced by elements, e.g. `<Foo as |concat|>`. The `All`
+   * visitor only runs for node types that have no visitor of their own, so
+   * ElementNode never reaches `stack` and has to be tracked separately.
+   */
+  let elementScope = [];
+
+  /**
+   * Whether `name` refers to the helper it appears to. A block param wins over
+   * both a helper and a keyword, so `{{#let x as |concat|}}` puts something
+   * else entirely behind the name for the length of the block.
+   */
+  function isShadowed(name) {
+    return (
+      stack.some((ancestor) => ancestor.blockParams?.includes(name)) ||
+      elementScope.some((element) => element.blockParams.includes(name))
+    );
+  }
+
+  function isClassBuilding(name) {
+    if (!CLASS_BUILDING_HELPERS.has(name)) return false;
+    if (strictMode && !KEYWORDS.has(name)) return false;
+
+    return !isShadowed(name);
+  }
+
+  /**
+   * `concat` fuses its params into one string, so a literal is only a class
+   * name of its own when a boundary separates it from its neighbours.
+   *
+   *   {{concat "a" " " "b"}}   -> two classes, rename each
+   *   {{concat "a" "-suffix"}} -> one class, fold it and rename the whole thing
+   *   {{concat "a" this.x}}    -> "a" fuses with an unknown value, so leave it
+   */
+  function renameConcatParams(node) {
+    const params = node.params ?? [];
+    const allLiterals = params.every((param) => param.type === 'StringLiteral');
+    const fuses = params.some(
+      (param, index) => !isWholeClassName(params, index),
+    );
+
+    if (fuses && allLiterals) {
+      const folded = params.map((param) => param.value).join('');
+      const renamed = renameClass(folded, postfix, classes);
+
+      // Collapsing the params is only worth the churn if it renamed something.
+      if (renamed !== folded) {
+        node.params = [recast.builders.literal('StringLiteral', renamed)];
+      }
+
+      return;
+    }
+
+    for (const [index, param] of params.entries()) {
+      if (!isWholeClassName(params, index)) continue;
+
+      renameLiteralClasses(param);
+    }
+  }
+
+  /**
    * Rename the string literals whose value reaches the class attribute.
    *
    *   {{if x "a" "b"}}                     -> both branches
    *   {{if x "a b"}}                       -> every class in the literal
    *   {{concat "a" " " "b"}}               -> every param
-   *   {{if x (concat "a" "-suffix") "b"}}  -> nested subexpressions too
+   *   {{concat "a" "-suffix"}}             -> folded to one class, then renamed
    *
    *   {{this.fooClass}}                    -> resolved at runtime, nothing to rename
    *   {{someHelper "a"}}                   -> opaque; use {{scopedClass "a"}}
    *   {{if (eq this.mode "a") "a" "b"}}    -> the branches, but not the comparand
+   *   {{concat "a" this.x}}                -> "a" fuses with an unknown value
    */
   function renameLiteralClasses(node) {
     if (node.type === 'StringLiteral') {
@@ -84,12 +188,18 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
       return;
     }
 
-    const classParamsOf = CLASS_BUILDING_HELPERS.get(getValue(node.path));
+    const name = getValue(node.path);
 
-    if (!classParamsOf) return;
+    if (!isClassBuilding(name)) return;
 
-    for (let param of classParamsOf(node.params ?? [])) {
-      renameLiteralClasses(param);
+    if (name === 'concat') {
+      renameConcatParams(node);
+
+      return;
+    }
+
+    for (let branch of (node.params ?? []).slice(1)) {
+      renameLiteralClasses(branch);
     }
   }
 
@@ -119,36 +229,45 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
       }
     },
 
-    ElementNode(node) {
-      // An element is in scope if its tag matches a tag selector, or if it
-      // carries an attribute named in a scoped attribute selector. We add the
-      // postfix class at most once regardless of how many things matched.
-      const shouldScope =
-        tags.has(node.tag) || elementHasScopedAttribute(node, attributes);
+    ElementNode: {
+      enter(node) {
+        // Only elements that introduce a name need tracking, which also keeps
+        // the stack balanced when a visitor removes a node and skips its exit.
+        if (node.blockParams?.length) elementScope.push(node);
 
-      if (!shouldScope) return;
+        // An element is in scope if its tag matches a tag selector, or if it
+        // carries an attribute named in a scoped attribute selector. We add the
+        // postfix class at most once regardless of how many things matched.
+        const shouldScope =
+          tags.has(node.tag) || elementHasScopedAttribute(node, attributes);
 
-      // check if class attribute already exists
-      const classAttr = node.attributes.find((attr) => attr.name === 'class');
+        if (!shouldScope) return;
 
-      if (!classAttr) {
-        // push class attribute
-        node.attributes.push(
-          recast.builders.attr('class', recast.builders.text(postfix)),
-        );
-      } else if (classAttr.value.type === 'TextNode') {
-        classAttr.value.chars += ' ' + postfix;
-      } else if (classAttr.value.type === 'ConcatStatement') {
-        // class="foo {{bar}}"
-        classAttr.value.parts.push(recast.builders.text(' ' + postfix));
-      } else {
-        // class={{this.foo}} — wrap in a concat so we can append the text part
-        classAttr.value = recast.builders.concat([
-          classAttr.value,
-          recast.builders.text(' ' + postfix),
-        ]);
-        classAttr.quoteType = '"';
-      }
+        // check if class attribute already exists
+        const classAttr = node.attributes.find((attr) => attr.name === 'class');
+
+        if (!classAttr) {
+          // push class attribute
+          node.attributes.push(
+            recast.builders.attr('class', recast.builders.text(postfix)),
+          );
+        } else if (classAttr.value.type === 'TextNode') {
+          classAttr.value.chars += ' ' + postfix;
+        } else if (classAttr.value.type === 'ConcatStatement') {
+          // class="foo {{bar}}"
+          classAttr.value.parts.push(recast.builders.text(' ' + postfix));
+        } else {
+          // class={{this.foo}} — wrap in a concat so we can append the text part
+          classAttr.value = recast.builders.concat([
+            classAttr.value,
+            recast.builders.text(' ' + postfix),
+          ]);
+          classAttr.quoteType = '"';
+        }
+      },
+      exit(node) {
+        if (elementScope.at(-1) === node) elementScope.pop();
+      },
     },
 
     All: {
@@ -229,10 +348,14 @@ export default function rewriteHbs(
   tags,
   postfix,
   attributes = new Set(),
+  strictMode = false,
 ) {
   let ast = recast.parse(hbs);
 
-  recast.traverse(ast, templatePlugin({ classes, tags, attributes, postfix }));
+  recast.traverse(
+    ast,
+    templatePlugin({ classes, tags, attributes, postfix, strictMode }),
+  );
 
   let result = recast.print(ast);
 

--- a/ember-scoped-css/src/lib/rewriteHbs.js
+++ b/ember-scoped-css/src/lib/rewriteHbs.js
@@ -62,15 +62,14 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
   /**
    * Rename the string literals whose value reaches the class attribute.
    *
-   * A literal qualifies only if every helper between it and the attribute
-   * builds its result out of that literal, so the walk descends through the
-   * params listed in CLASS_BUILDING_HELPERS and stops everywhere else. A
-   * literal that some other helper merely reads is data: postfixing it would
-   * change what that helper computes, as in `{{if (eq this.mode "a") "a" "b"}}`
-   * where only the two branches are class names.
+   *   {{if x "a" "b"}}                     -> both branches
+   *   {{if x "a b"}}                       -> every class in the literal
+   *   {{concat "a" " " "b"}}               -> every param
+   *   {{if x (concat "a" "-suffix") "b"}}  -> nested subexpressions too
    *
-   * A path expression such as `{{this.fooClass}}` resolves at runtime, so it
-   * carries no class name to rename at build time.
+   *   {{this.fooClass}}                    -> resolved at runtime, nothing to rename
+   *   {{someHelper "a"}}                   -> opaque; use {{scopedClass "a"}}
+   *   {{if (eq this.mode "a") "a" "b"}}    -> the branches, but not the comparand
    */
   function renameLiteralClasses(node) {
     if (node.type === 'StringLiteral') {

--- a/ember-scoped-css/src/lib/rewriteHbs.js
+++ b/ember-scoped-css/src/lib/rewriteHbs.js
@@ -42,6 +42,21 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
     return scopedClassCandidates.some((candidate) => candidate === str);
   }
 
+  /**
+   * Only string literals are reachable: a path expression such as
+   * `{{this.fooClass}}` resolves at runtime, so it carries no class name to
+   * rename at build time.
+   */
+  function renameLiteralClasses(mustache) {
+    recast.traverse(mustache, {
+      StringLiteral(node) {
+        const renamedClass = renameClass(node.value, postfix, classes);
+
+        node.value = renamedClass;
+      },
+    });
+  }
+
   return {
     AttrNode(node) {
       if (node.name === 'class') {
@@ -56,19 +71,14 @@ export function templatePlugin({ classes, tags, attributes, postfix }) {
 
               part.chars = renamedClass;
             } else if (part.type === 'MustacheStatement') {
-              recast.traverse(part, {
-                StringLiteral(node) {
-                  const renamedClass = renameClass(
-                    node.value,
-                    postfix,
-                    classes,
-                  );
-
-                  node.value = renamedClass;
-                },
-              });
+              renameLiteralClasses(part);
             }
           }
+        } else if (node.value.type === 'MustacheStatement') {
+          // Glimmer parses a quoted attribute value as a ConcatStatement and an
+          // unquoted one as a bare MustacheStatement, so `class={{if x "a"}}`
+          // lands here rather than in the branch above.
+          renameLiteralClasses(node.value);
         }
       }
     },

--- a/ember-scoped-css/src/lib/rewriteHbs.js
+++ b/ember-scoped-css/src/lib/rewriteHbs.js
@@ -39,15 +39,13 @@ function elementHasScopedAttribute(node, attributes) {
  * Any other helper is opaque: it may return a class name, but what it does with
  * its arguments is unknown, so those arguments are left alone.
  * `{{scopedClass "..."}}` is the way to rename a literal such a helper receives.
+ *
+ * Matching is by name, so a block param that shadows one of these is checked
+ * for. A strict-mode template has to import `concat`, and the module it came
+ * from is not visible here, so a `concat` imported from elsewhere is taken at
+ * face value.
  */
 const CLASS_BUILDING_HELPERS = new Set(['concat', 'if', 'unless']);
-
-/**
- * Of the above, the ones a strict-mode template gets for free. `concat` is not
- * among them: strict mode requires it to be imported, and which module it came
- * from is not visible from the template, so there it could be any function.
- */
-const KEYWORDS = new Set(['if', 'unless']);
 
 function endsAtClassBoundary(value) {
   return /\s$/.test(value);
@@ -84,13 +82,7 @@ function isWholeClassName(params, index) {
   return boundedLeft && boundedRight;
 }
 
-export function templatePlugin({
-  classes,
-  tags,
-  attributes,
-  postfix,
-  strictMode = false,
-}) {
+export function templatePlugin({ classes, tags, attributes, postfix }) {
   let stack = [];
   // scoped-class is a global we allow in hbs
   // scopedClass is importable, and we'll error if someone tries to rename it
@@ -122,10 +114,7 @@ export function templatePlugin({
   }
 
   function isClassBuilding(name) {
-    if (!CLASS_BUILDING_HELPERS.has(name)) return false;
-    if (strictMode && !KEYWORDS.has(name)) return false;
-
-    return !isShadowed(name);
+    return CLASS_BUILDING_HELPERS.has(name) && !isShadowed(name);
   }
 
   /**
@@ -348,14 +337,10 @@ export default function rewriteHbs(
   tags,
   postfix,
   attributes = new Set(),
-  strictMode = false,
 ) {
   let ast = recast.parse(hbs);
 
-  recast.traverse(
-    ast,
-    templatePlugin({ classes, tags, attributes, postfix, strictMode }),
-  );
+  recast.traverse(ast, templatePlugin({ classes, tags, attributes, postfix }));
 
   let result = recast.print(ast);
 

--- a/test-apps/vite-app-with-compat/src/components/in-app/legacy-concat.css
+++ b/test-apps/vite-app-with-compat/src/components/in-app/legacy-concat.css
@@ -1,0 +1,11 @@
+.fused-part {
+  color: rgb(11, 22, 33);
+}
+
+.one {
+  color: rgb(44, 55, 66);
+}
+
+.two {
+  font-weight: bold;
+}

--- a/test-apps/vite-app-with-compat/src/components/in-app/legacy-concat.hbs
+++ b/test-apps/vite-app-with-compat/src/components/in-app/legacy-concat.hbs
@@ -1,0 +1,2 @@
+<p data-test-fused class={{concat "fused" "-part"}}>fused</p>
+<p data-test-separate class={{concat "one" " " "two"}}>separate</p>

--- a/test-apps/vite-app-with-compat/tests/in-app/legacy-concat-test.gts
+++ b/test-apps/vite-app-with-compat/tests/in-app/legacy-concat-test.gts
@@ -1,0 +1,35 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import Legacy from 'vite-app-with-compat/components/in-app/legacy-concat';
+
+import { scopedClass } from 'ember-scoped-css/test-support';
+
+const modulePath = 'vite-app-with-compat/components/in-app/legacy-concat';
+
+module('[In App] legacy-concat (hbs)', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('postfixes the class concat builds out of fragments', async function (assert) {
+    // Postfixing "fused" on its own would emit fused_HASH-part, which matches
+    // no selector the CSS rewrite produces.
+    await render(<template><Legacy /></template>);
+
+    assert
+      .dom('[data-test-fused]')
+      .hasClass(scopedClass('fused-part', modulePath));
+    assert.dom('[data-test-fused]').hasStyle({ color: 'rgb(11, 22, 33)' });
+  });
+
+  test('postfixes each class when a boundary separates them', async function (assert) {
+    await render(<template><Legacy /></template>);
+
+    assert.dom('[data-test-separate]').hasClass(scopedClass('one', modulePath));
+    assert.dom('[data-test-separate]').hasClass(scopedClass('two', modulePath));
+    assert.dom('[data-test-separate]').hasStyle({
+      color: 'rgb(44, 55, 66)',
+      fontWeight: '700',
+    });
+  });
+});

--- a/test-apps/vite-app/src/components/in-app/unquoted-class.css
+++ b/test-apps/vite-app/src/components/in-app/unquoted-class.css
@@ -1,0 +1,7 @@
+.chosen {
+  color: rgb(10, 20, 30);
+}
+
+.other {
+  color: rgb(40, 50, 60);
+}

--- a/test-apps/vite-app/src/components/in-app/unquoted-class.css
+++ b/test-apps/vite-app/src/components/in-app/unquoted-class.css
@@ -5,3 +5,7 @@
 .other {
   color: rgb(40, 50, 60);
 }
+
+.extra {
+  font-weight: bold;
+}

--- a/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
+++ b/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
@@ -1,3 +1,5 @@
+import { concat } from '@ember/helper';
+
 const yes = true;
 const no = false;
 const eq = (a, b) => a === b;
@@ -11,4 +13,5 @@ const mode = 'chosen';
     data-test-comparand
     class={{if (eq mode "chosen") "chosen" "other"}}
   >comparand</p>
+  <p data-test-concat class={{concat "chosen" " " "extra"}}>concat</p>
 </template>

--- a/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
+++ b/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
@@ -1,0 +1,8 @@
+const yes = true;
+const no = false;
+
+<template>
+  <p data-test-chosen class={{if yes "chosen" "other"}}>chosen</p>
+  <p data-test-fallback class={{if no "chosen" "other"}}>fallback</p>
+  <p data-test-global class={{if yes "not-in-css"}}>global</p>
+</template>

--- a/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
+++ b/test-apps/vite-app/src/components/in-app/unquoted-class.gjs
@@ -1,8 +1,14 @@
 const yes = true;
 const no = false;
+const eq = (a, b) => a === b;
+const mode = 'chosen';
 
 <template>
   <p data-test-chosen class={{if yes "chosen" "other"}}>chosen</p>
   <p data-test-fallback class={{if no "chosen" "other"}}>fallback</p>
   <p data-test-global class={{if yes "not-in-css"}}>global</p>
+  <p
+    data-test-comparand
+    class={{if (eq mode "chosen") "chosen" "other"}}
+  >comparand</p>
 </template>

--- a/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
+++ b/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
@@ -30,4 +30,15 @@ module('[In App] unquoted class attribute', function (hooks) {
 
     assert.dom('[data-test-global]').hasClass('not-in-css');
   });
+
+  test('leaves a comparand that happens to match a class alone', async function (assert) {
+    // The comparand spells a real class name, so postfixing it would make the
+    // comparison fail and select the other branch.
+    await render(<template><UnquotedClass /></template>);
+
+    assert
+      .dom('[data-test-comparand]')
+      .hasClass(scopedClass('chosen', modulePath));
+    assert.dom('[data-test-comparand]').hasStyle({ color: 'rgb(10, 20, 30)' });
+  });
 });

--- a/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
+++ b/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
@@ -1,0 +1,33 @@
+import { render } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+
+import UnquotedClass from 'vite-app/components/in-app/unquoted-class';
+
+import { scopedClass } from 'ember-scoped-css/test-support';
+
+const modulePath = 'vite-app/components/in-app/unquoted-class';
+
+module('[In App] unquoted class attribute', function (hooks) {
+  setupRenderingTest(hooks);
+
+  test('rewrites the literals of an unquoted class attribute', async function (assert) {
+    await render(<template><UnquotedClass /></template>);
+
+    assert
+      .dom('[data-test-chosen]')
+      .hasClass(scopedClass('chosen', modulePath));
+    assert.dom('[data-test-chosen]').hasStyle({ color: 'rgb(10, 20, 30)' });
+
+    assert
+      .dom('[data-test-fallback]')
+      .hasClass(scopedClass('other', modulePath));
+    assert.dom('[data-test-fallback]').hasStyle({ color: 'rgb(40, 50, 60)' });
+  });
+
+  test('leaves a class that is not in the co-located CSS alone', async function (assert) {
+    await render(<template><UnquotedClass /></template>);
+
+    assert.dom('[data-test-global]').hasClass('not-in-css');
+  });
+});

--- a/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
+++ b/test-apps/vite-app/tests/in-app/unquoted-class-test.gjs
@@ -31,6 +31,20 @@ module('[In App] unquoted class attribute', function (hooks) {
     assert.dom('[data-test-global]').hasClass('not-in-css');
   });
 
+  test('postfixes the classes of an imported concat', async function (assert) {
+    // concat has to be imported in strict mode, so it is trusted by name.
+    await render(<template><UnquotedClass /></template>);
+
+    assert
+      .dom('[data-test-concat]')
+      .hasClass(scopedClass('chosen', modulePath));
+    assert.dom('[data-test-concat]').hasClass(scopedClass('extra', modulePath));
+    assert.dom('[data-test-concat]').hasStyle({
+      color: 'rgb(10, 20, 30)',
+      fontWeight: '700',
+    });
+  });
+
   test('leaves a comparand that happens to match a class alone', async function (assert) {
     // The comparand spells a real class name, so postfixing it would make the
     // comparison fail and select the other branch.


### PR DESCRIPTION
## Problem

Glimmer parses a **quoted** attribute value as a `ConcatStatement` and an **unquoted** one as a bare `MustacheStatement`. The `AttrNode` visitor in `rewriteHbs.js` handled `TextNode` and `ConcatStatement` only, so the unquoted form fell through untouched:

```hbs
class="{{if x 'a' 'b'}}"   {{!-- rewritten to a_HASH / b_HASH --}}
class={{if x 'a' 'b'}}     {{!-- untouched, so the styles silently never apply --}}
```

Nothing errors and nothing warns — the class name just stays unscoped and the rule never matches. That silence is what makes it worth fixing.

## Fix

Three parts. Parts 2 and 3 came out of review, and both correct behaviour that predates this PR on the quoted path.

**1. Handle the unquoted form.** A bare `MustacheStatement` attribute value gets the same treatment as the mustache parts of a `ConcatStatement`.

**2. Rename only literals that reach the class attribute.** The original traversal renamed *every* `StringLiteral` in the mustache, including ones that are data rather than class names:

```hbs
{{if (checkAlphabet "a" "b") "a" "b"}}
{{!-- renaming everything: --}} {{if (checkAlphabet "a_HASH" "b_HASH") "a_HASH" "b_HASH"}}
{{!-- this PR:             --}} {{if (checkAlphabet "a" "b") "a_HASH" "b_HASH"}}
```

`{{if (eq this.mode "a") "a" "b"}}` is the same defect with teeth: postfixing the comparand stops the comparison ever matching, selecting the wrong branch at runtime. So the walk descends from the attribute value and propagates only through helpers whose result is assembled from their own params:

| slot | position | descend? |
| --- | --- | --- |
| the mustache's own value | class name | yes |
| `concat` params | class name, subject to part 3 | yes |
| `if`/`unless` params 1..n — the branches | class name (one becomes the value) | yes |
| `if`/`unless` param 0 — the condition | data (it becomes a boolean) | **no** |
| any param of an unrecognised helper | data (contract unknown) | **no** |

**3. Check the name is really that helper, and respect `concat`'s boundaries.**

*Shadowing.* A block param wins over both a helper and a keyword, and a shadowed name is syntactically identical to the real one — `{{#let x as |concat|}}` puts something else entirely behind it. Block params are now tracked and shadowed names treated as opaque. Element block params (`<Foo as |concat|>`) needed separate tracking: the `All` visitor only runs for node types that have no visitor of their own, so `ElementNode` never reached the ancestor stack.

*Fusing.* `concat` joins its params into one string, so a literal is only a class name of its own when a boundary separates it from its neighbours:

```hbs
{{concat "a" "-suffix"}}   {{!-- ONE class, a-suffix --}}
```

Postfixing the `"a"` emitted `a_HASH-suffix` while the CSS rewrite turned `.a-suffix` into `.a-suffix_HASH` — the postfix ended up buried mid-name and matched nothing. Literal params are folded before renaming (`a-suffix` -> `a-suffix_HASH`), and where a param is dynamic only the literals a boundary separates from it are renamed (`{{concat "a " this.x}}` yes, `{{concat "a" this.x}}` no).

### Known limitations

- A literal passed to an **unrecognised** helper (`{{myClassHelper "a"}}`) is not renamed. `{{scopedClass "a"}}` is the sanctioned way to rename a literal, so there is an explicit opt-in. This is a false negative — a class quietly not renamed — rather than corruption, and it is pinned by a test.
- Matching is **by name**. A strict-mode template has to import `concat`, and the module it came from is not visible from the template, so a `concat` imported from elsewhere is taken at face value. An earlier revision of this PR distrusted `concat` in strict mode instead; that was reverted because it removed renaming that already works today (the quoted `class="{{concat 'a' ' ' 'b'}}"` path is handled in `.gjs` on `main`), and a regression against shipped behaviour is a worse trade than the residual risk. What remains is `main`'s exposure minus the shadowing hole.
- `{{concat "a" (if C "-on" "-off")}}` is left alone, though its value set (`a-on`, `a-off`) is statically enumerable and could in principle be distributed into `{{if C "a-on_HASH" "a-off_HASH"}}`. Deliberately out of scope here; it is a new capability rather than a correctness fix, and it needs a cap on combinatorial blowup.

## Behaviour

With `classes = {a, b}` and `global-thing` deliberately absent from the sibling CSS:

| input | output |
| --- | --- |
| `class={{if x "a" "b"}}` | `class={{if x "a_HASH" "b_HASH"}}` |
| `class={{if x "global-thing"}}` | unchanged |
| `class={{if x "a" "global-thing"}}` | only `"a"` rewritten |
| `class={{concat "a" " " "b"}}` | both rewritten |
| `class={{this.fooClass}}` | unchanged |
| `class="a {{if x 'b'}}"` | unchanged from today |
| `class={{if (eq this.mode "a") "a" "b"}}` | only the branches rewritten |
| `class={{someHelper "a"}}` | unchanged |
| `class={{concat "a" "-suffix"}}` | folded, then rewritten as one class |
| `{{#let x as \|concat\|}}…{{concat "a" " " "b"}}` | unchanged (shadowed) |

Three properties make this safe, all covered explicitly: **globals are left alone** (the `classesInCss` guard), **data is left alone** (position in the expression tree), and **shadowed names are left alone**.

## Testing

- `rewriteHbs.classes.test.ts` — 36 cases across the rows above plus regressions: already-postfixed literals aren't double-postfixed, `data-x=` and `@class=` untouched, `unless` and two-param `if` behave like `if`, block-param scope does not leak past its block, and elements scoped by tag still get the postfix class.
- Each round's tests were run against the previous commit of this branch and fail there.
- **Browser e2e, chosen so the bug changes rendered style rather than just the emitted string:**
  - `vite-app` (strict mode): `{{if (eq mode "chosen") "chosen" "other"}}` — without the fix the comparand is postfixed, the comparison fails, and the wrong branch renders. Plus an imported `{{concat}}`, covering the case the reverted strict-mode revision would have regressed.
  - `vite-app-with-compat` (loose mode): `{{concat "fused" "-part"}}` against a real `.fused-part` rule. Confirmed failing without the fix.
- **Full CI test-app matrix green** — all 6 apps, dev **and** prod builds. This matters because parts 2 and 3 change the pre-existing quoted path. `vite-app-with-compat`'s `{{if @isTrue (scopedClass "is-true") (scopedClass "is-false")}}` still works: `scopedClass` subexpressions in branch slots are handled by the dedicated `SubExpression` visitor.
- Full addon suite green (147 tests). `pnpm lint` green for the addon and both test-apps.

## Relationship to soxhub/auditboard-frontend#41310

That PR adds an ESLint rule (`auditboard/no-unrewritable-scoped-class`) covering these gaps from the consumer side.

- Its **JS-computed case remains necessary** — a class name computed in JS still can't be resolved at build time.
- Its **unquoted-literal case is redundant only where this PR rewrites correctly**. For a literal handed to an unrecognised helper or a shadowed one, this PR deliberately does *not* rewrite, so consumer-side detection still has a job there.

<details>
<summary>🤖 Claude interactions</summary>

**Goal given to Claude:** Fix three independent defects in this fork and land them as separate PRs (different risk profiles), each with a changeset. This is PR 1 of 3. The unquoted-`class` gap was described as the highest-value of the three, with the expected behaviour table supplied up front and already prototyped by hand.

**Explicit instructions:** don't change public API or option names; verify against the repo's own test suite and test-apps rather than by inspection; add tests for every row including the global-class and path-expression rows.

**Notable findings and decisions:**

- **There is no changeset mechanism in this repo.** No `.changeset/`, no `@changesets/cli`, zero references to `changeset`. `release-plan` derives the changelog from PR labels + titles (RELEASE.md). Flagged rather than writing files the tooling would ignore; this PR wants the `bug` label.
- Verified each behaviour row against the real implementation before writing assertions, rather than predicting output.
- **Environment issue found, not caused by this PR:** `test-apps/*/package.json` have no `volta.extends`, so they default to Node 22 where `RegExp.escape` (used in `lib/path/utils.js`) does not exist and every test-app build fails. Test-apps were run via `volta run --node 24.4.0`. Reported separately.

**Round 2 — review feedback from @NullVoxPopuli (#r3722773426), "what happens if a string happens to match a class but isn't a class?"**

- Claude reproduced it rather than reasoning about it, confirmed the review was right, and found the same corruption already happened on `main` in the **quoted** form — so this PR had been propagating an existing defect to the more common spelling.
- Claude flagged that its own description had **overstated** the `classesInCss` guard as what made this safe: the guard limits blast radius but cannot tell a class name from a coincidence. Corrected.
- Claude also flagged that its own test asserting `{{if x (concat "a" "-suffix") "b"}}` renamed inside the subexpression was the weak spot, since no purely syntactic depth-based rule separates that from the `checkAlphabet` case.
- Decision, confirmed before implementing: key on *position* rather than presence in the subtree, and fix the quoted path at the same time.

**Round 3 — two follow-ups raised by the requester after discussion with @NullVoxPopuli.**

*"Make sure the allowlisted helpers are not shadowed."* Claude established by experiment, not assumption, that: a block param produces a `PathExpression` indistinguishable from the built-in; `concat` fails to compile in strict mode without an import while `if`/`unless` compile fine; `env.strictMode` is available to the AST transform but `env.locals` is empty under content-tag's eval-based scope, and `jsutils` offers no way to resolve a binding's origin. A first attempt was wrong — element block params never reached the ancestor stack — which Claude found by instrumenting the traversal after a test failed, tracing it to `All` only running for node types with no visitor of their own.

*"Does `{{concat "a" "-suffix"}}` actually work if the CSS selects `a-suffix`?"* Claude ran the template and the CSS rewriter together and confirmed it does **not**: the template emitted `a_HASH-suffix` while the CSS produced `.a-suffix_HASH`. The test in this PR had been asserting that broken behaviour. Fixed by folding literal params before renaming, with a boundary rule for dynamic params, and covered by a loose-mode browser e2e since unit tests alone never compare the emitted class against the rewritten CSS.

**Round 4 — the requester asked what `concat` does with none of this work applied.**

Claude measured `main` directly rather than describing it: there is no notion of `concat` there at all, just "rename every string literal in a quoted mustache, ignore unquoted ones". That made two things clear. `main` is *less* sound than the allowlist, since it renames literals inside any helper, shadowed or not. But it also showed that distrusting `concat` in strict mode — which Claude had implemented and flagged as the open question — would **regress a case that works on `main` today**, because the quoted form has always been handled in `.gjs`. Claude had previously described that as a lost improvement rather than a regression, which understated it. On that basis the strict-mode distrust was reverted in favour of shadow-checking alone, and a `.gjs` e2e was added for imported `concat` to pin the case that would have regressed.

The requester also asked whether `{{concat "a" (if C "-on" "-off")}}` could ideally yield `a-on_HASH`/`a-off_HASH`. Claude confirmed it is attainable — the value set is statically enumerable and concat distributes over `if` — but recommended against bundling it here, and it is recorded as a known limitation instead.

`pr-readiness` was run before each push.

</details>