### PR TITLE
Postfix every class passed to scopedClass()

### DIFF
--- a/ember-scoped-css/src/build/babel-plugin.js
+++ b/ember-scoped-css/src/build/babel-plugin.js
@@ -90,11 +90,9 @@ export const scopedCSS = (config) => (env, options, workingDirectory) => {
           }
 
           const original = path.node.arguments[0].value;
-          const renamed = renameClass(
-            original,
-            state.postfix,
-            new Set([original]),
-          );
+          // The co-located CSS is not parsed on this path, so there is nothing
+          // to check the classes against: naming them explicitly is the opt-in.
+          const renamed = renameClass(original, state.postfix);
           const transformedString = env.types.stringLiteral(renamed);
 
           path.replaceWith(transformedString);

--- a/ember-scoped-css/src/build/babel-plugin.test.ts
+++ b/ember-scoped-css/src/build/babel-plugin.test.ts
@@ -1,0 +1,113 @@
+import path from 'node:path';
+
+import * as babel from '@babel/core';
+import { describe, expect, it } from 'vitest';
+
+import { hash } from '../lib/path/hash-from-module-path.js';
+import { paths } from '../lib/path/utils.paths.test.js';
+import { scopedCSS } from './babel-plugin.js';
+
+const modulePath = 'vite-app/components/scoped-class-helper';
+const postfix = hash(modulePath);
+const filename = path.join(
+  paths.viteApp,
+  'src/components/scoped-class-helper.js',
+);
+
+async function transform(code: string) {
+  const result = await babel.transformAsync(code, {
+    plugins: [[scopedCSS({}), {}]],
+    filename,
+    cwd: paths.viteApp,
+    root: paths.viteApp,
+    babelrc: false,
+    configFile: false,
+  });
+
+  return result?.code;
+}
+
+/** The value the `scopedClass(...)` call is replaced with. */
+async function scopedClassOf(argument: string) {
+  const code = await transform(
+    [
+      `import { scopedClass } from 'ember-scoped-css';`,
+      `export const result = scopedClass(${argument});`,
+    ].join('\n'),
+  );
+
+  const match = code?.match(/export const result = "(.*)";/);
+
+  return match?.[1];
+}
+
+describe('scopedClass()', () => {
+  it('postfixes a single class', async () => {
+    expect(await scopedClassOf(`'bar-complete'`)).to.equal(
+      `bar-complete_${postfix}`,
+    );
+  });
+
+  it('postfixes every class of a multi-class argument', async () => {
+    expect(await scopedClassOf(`'column column-hidden'`)).to.equal(
+      `column_${postfix} column-hidden_${postfix}`,
+    );
+  });
+
+  it('postfixes every class regardless of how they are spaced', async () => {
+    // Leading and trailing whitespace survives; whitespace between classes
+    // collapses to a single space.
+    expect(await scopedClassOf(`'  column   column-hidden  '`)).to.equal(
+      `  column_${postfix} column-hidden_${postfix}  `,
+    );
+  });
+
+  it('agrees with the test-support helper, which the app asserts against', async () => {
+    const { scopedClass } = await import('../runtime/test-support.js');
+
+    expect(await scopedClassOf(`'column column-hidden'`)).to.equal(
+      scopedClass('column column-hidden', modulePath),
+    );
+  });
+
+  it('does not postfix a class twice', async () => {
+    expect(await scopedClassOf(`'bar-complete_${postfix}'`)).to.equal(
+      `bar-complete_${postfix}`,
+    );
+  });
+
+  it('removes the import', async () => {
+    const code = await transform(
+      [
+        `import { scopedClass } from 'ember-scoped-css';`,
+        `export const result = scopedClass('bar-complete');`,
+      ].join('\n'),
+    );
+
+    expect(code).to.not.include('ember-scoped-css');
+  });
+
+  describe('rejects arguments it cannot resolve at build time', () => {
+    it('throws on a dynamic argument', async () => {
+      await expect(
+        transform(
+          [
+            `import { scopedClass } from 'ember-scoped-css';`,
+            `export const result = scopedClass(someVariable);`,
+          ].join('\n'),
+        ),
+      ).rejects.toThrow(/only accepts a single, non-dynamic, string literal/);
+    });
+
+    it('throws on more than one argument', async () => {
+      await expect(
+        transform(
+          [
+            `import { scopedClass } from 'ember-scoped-css';`,
+            `export const result = scopedClass('column', 'column-hidden');`,
+          ].join('\n'),
+        ),
+      ).rejects.toThrow(/only accepts a single, non-dynamic, string literal/);
+    });
+  });
+});

--- a/ember-scoped-css/src/lib/renameClass.js
+++ b/ember-scoped-css/src/lib/renameClass.js
@@ -10,6 +10,11 @@ export function splitClassList(classList) {
 }
 
 /**
+ * Postfixes every class in `className`, which may be a space-separated list.
+ *
+ * `classesInCss` is consulted one class at a time, so it has to be keyed on
+ * individual class names — a Set built from a whole space-separated list
+ * matches nothing. Omit it to postfix every class unconditionally.
  *
  * @param {string} className
  * @param {string} postfix

--- a/test-apps/vite-app/src/components/scoped-class.gts
+++ b/test-apps/vite-app/src/components/scoped-class.gts
@@ -1,3 +1,4 @@
 import { scopedClass } from 'ember-scoped-css';
 
 export const transformed = scopedClass('foo');
+export const transformedMultiple = scopedClass('foo bar');

--- a/test-apps/vite-app/tests/in-app/scoped-class-transform-test.ts
+++ b/test-apps/vite-app/tests/in-app/scoped-class-transform-test.ts
@@ -1,6 +1,9 @@
 import { module, test } from 'qunit';
 
-import { transformed } from 'vite-app/components/scoped-class.gts';
+import {
+  transformed,
+  transformedMultiple,
+} from 'vite-app/components/scoped-class.gts';
 import { scopedClass } from 'ember-scoped-css/test-support';
 
 module('[In App] scopedClass() build utility', function () {
@@ -9,6 +12,14 @@ module('[In App] scopedClass() build utility', function () {
     assert.strictEqual(
       transformed,
       scopedClass('foo', 'vite-app/components/scoped-class')
+    );
+  });
+
+  test('postfixes every class of a multi-class argument', function (assert) {
+    assert.notStrictEqual(transformedMultiple, 'foo bar');
+    assert.strictEqual(
+      transformedMultiple,
+      scopedClass('foo bar', 'vite-app/components/scoped-class')
     );
   });
 });


### PR DESCRIPTION
## Problem

`babel-plugin.js` called `renameClass(original, state.postfix, new Set([original]))`. `renameClass` splits its input on whitespace and checks `Set` membership **one class at a time**, so a `Set` built from the whole argument can only ever match a single-class string:

```js
scopedClass('bar-complete')         // -> 'bar-complete_HASH'    correct
scopedClass('column column-hidden') // -> 'column column-hidden' SILENTLY UNCHANGED
```

No token matched, nothing was renamed, and the returned string still looked plausible. This is the worst failure mode available: it looks fixed and is not.

There's a tell that makes it unambiguous — the current code *does* run, it just renames nothing:

```js
scopedClass('  a   b  ')            // -> '  a b  '   whitespace collapsed, nothing renamed
```

## Decision: rename every whitespace-separated token

The brief offered two options — (a) rename every token, or (b) throw a build error and make the caller use one `scopedClass()` per class. I went with **(a)**, and the evidence made this one-sided rather than a judgement call. Every sibling path already renames every token:

| path | `scopedClass('column column-hidden')` |
| --- | --- |
| `test-support` runtime helper | `column_HASH column-hidden_HASH` |
| hbs `{{scoped-class "…"}}` and `{{scopedClass "…"}}` | `column_HASH column-hidden_HASH` |
| build-time JS helper | **unchanged** ← the bug |

Two things follow:

1. **The multi-class string is the documented interface.** `docs/lint-rules.md` uses `{{scoped-class 'first-class second-class'}}` as its example of *correct* use. Option (b) would make the build-time JS helper throw on input the hbs form documents as supported.
2. **Option (b) would break build↔test-support parity.** `test-apps/vite-app/tests/in-app/scoped-class-transform-test.ts` asserts the build-time output equals the `test-support` output. Under (b), `scopedClass('a b')` would be a build error while `test-support` happily returns `a_HASH b_HASH` — the two helpers would diverge, and assertions would be unwritable for a case the hbs form supports.

So the `new Set([original])` is simply a mistake, not a policy. Omitting `classesInCss` gives exactly the semantics the other two paths already have. The co-located CSS isn't parsed on this path at all, so there is nothing to check the classes against — naming them explicitly *is* the opt-in.

This does mean a caller who passes a global class name alongside a scoped one will now have both postfixed. That hazard already exists identically in the hbs helper and is inherent to a helper that renames unconditionally; making the JS path quieter than the hbs path is not a fix for it.

`renameClass`'s JSDoc now documents the per-class `Set` contract that caused this, so the trap isn't re-set later.

## Testing

- New `ember-scoped-css/src/build/babel-plugin.test.ts` (9 cases): single-class, multi-class, and extra-whitespace inputs; no double-postfixing; import removal; and the existing throws for a dynamic argument and for wrong arity, so those guards are pinned too.
- One test asserts the build-time output **equals** `test-support`'s `scopedClass()` for a multi-class argument — the parity that option (b) would have broken.
- Extra-whitespace semantics are pinned as they actually behave: leading/trailing whitespace survives, whitespace between classes collapses to a single space.
- With the source fix reverted, exactly 3 of the 9 fail (multi-class, whitespace, parity) and the other 6 pass.
- `test-apps/vite-app` gains a multi-class export asserted end-to-end in the browser against `test-support`.
- Full addon suite green (121 tests). **Full CI test-app matrix green** — all 6 apps (`v2-addon-bundled`, `vite-app`, `vite-app-layer`, `vite-app-with-compat`, `vite-app-with-compat-pods`, `vite-app-monorepo`), dev **and** prod builds, since this changes shared rename semantics.

## Relationship to soxhub/auditboard-frontend#41310

That PR adds an ESLint rule (`auditboard/no-unrewritable-scoped-class`) covering these gaps from the consumer side. That rule stays necessary for the JS-computed case, which no change here affects.

<details>
<summary>🤖 Claude interactions</summary>

**Goal given to Claude:** Fix three independent defects in this fork as separate PRs (different risk profiles), each with a changeset. This is PR 2 of 3. The brief described the bug precisely, asked Claude to **decide** between renaming every token and throwing a build error, to state the rationale in the PR body, and to add tests for single-class, multi-class and extra-whitespace inputs. The brief noted that (b) would be "consistent with existing behaviour" since the helper already throws on a non-literal argument.

**Explicit instructions:** don't change public API or option names; verify against the repo's own test suite and test-apps rather than by inspection.

**Key decision — Claude argued against the brief's leaning and chose (a):**

The brief's case for (b) was consistency with the existing throw. Claude checked the other two `renameClass` callers before deciding and found the consistency argument actually points the other way: `test-support`'s `scopedClass` and the hbs `{{scoped-class}}` helper both already rename every token, and `docs/lint-rules.md` documents a *multi-class* string as correct use of the helper. Under (b) the build-time helper would throw on documented-supported input and diverge from `test-support`, breaking the parity that `scoped-class-transform-test.ts` asserts. Verified by running all three paths on the same input rather than reasoning from the source. The rationale is stated in the PR body as requested.

**Notable findings and decisions:**

- Reproduced the bug directly through the real babel pipeline before changing anything, which surfaced the `'  a   b  '` → `'  a b  '` tell: the plugin visibly runs and renames nothing. That became a test.
- Considered whether the fix should be a guard in `babel-plugin.js` plus a `Set`-based check, and rejected it: the babel plugin has no access to the co-located CSS class list (it only derives a postfix from the module path), so it *cannot* discriminate scoped from global classes. Passing no `Set` is the honest expression of that.
- Noted the residual hazard (a global class passed alongside a scoped one gets postfixed) and stated it explicitly in the PR body rather than leaving it implicit — it is pre-existing and identical in the hbs path.
- Ran the **entire CI test-app matrix**, not just one app, because this changes semantics shared by the hbs helper, the test-support helper and the build transform.
- **There is no changeset mechanism in this repo** — no `.changeset/`, no `@changesets/cli`, zero references to `changeset`. `release-plan` derives the changelog from PR labels + titles (RELEASE.md). Flagged back to the requester rather than writing changeset files the tooling would ignore; this PR is labelled `bug` with a user-facing title instead.
- **Environment issue found, not caused by this PR:** `test-apps/*/package.json` lack `volta.extends`, so they default to Node 22 where `RegExp.escape` (used in `lib/path/utils.js`) doesn't exist and every test-app build fails. Test-apps were run via `volta run --node 24.4.0`. Pre-existing; reported separately rather than bundled here.
- A `pr-readiness` comment-hygiene pass was run before opening: 1 comment rewritten (cut from four lines to two, keeping only the constraint that stops someone re-adding the `Set`), 0 deleted.

</details>