### PR TITLE
Match the imported scopedClass form in the template-lint rule

### DIFF
--- a/docs/lint-rules.md
+++ b/docs/lint-rules.md
@@ -1,9 +1,11 @@
 ## scoped-class-helper
 
-This rule checks if `scoped-class` helper has one positional param of type StringLiteral.
-The following example shows the correct use of the helper:
+This rule checks if the helper has one positional param of type StringLiteral. It
+applies to both spellings: the imported `scopedClass` and the legacy hbs global
+`scoped-class`. The following examples show the correct use of the helper:
 
 ```hbs
+<SomeComponent @class={{scopedClass 'first-class second-class'}} />
 <SomeComponent @class={{scoped-class 'first-class second-class'}} />
 ```
 
@@ -14,6 +16,8 @@ This rule forbids the following:
 1. Wrong number of positional params
 
 ```hbs
+<SomeComponent @class={{scopedClass}} />
+<SomeComponent @class={{scopedClass 'first-class' 'second-param'}} />
 <SomeComponent @class={{scoped-class}} />
 <SomeComponent @class={{scoped-class 'first-class' 'second-param'}} />
 ```
@@ -21,5 +25,6 @@ This rule forbids the following:
 2. Dynamic properties
 
 ```hbs
-<SomeComponet @class={{scoped-class this.myClass}} />
+<SomeComponent @class={{scopedClass this.myClass}} />
+<SomeComponent @class={{scoped-class this.myClass}} />
 ```

--- a/ember-scoped-css/src/template-lint/plugin.js
+++ b/ember-scoped-css/src/template-lint/plugin.js
@@ -1,24 +1,31 @@
 import { generateRuleTests, Rule } from 'ember-template-lint';
 
+/**
+ * `scoped-class` is the legacy hbs global; `scopedClass` is the form consumers
+ * import. Both compile through the same build-time rewrite, so both are subject
+ * to the same restrictions.
+ */
+const HELPER_NAMES = new Set(['scoped-class', 'scopedClass']);
+
 class ScopedClassHelperRule extends Rule {
   visitor() {
     const checkScopedClass = function (node) {
-      if (node.path.original !== 'scoped-class') {
+      const helperName = node.path.original;
+
+      if (!HELPER_NAMES.has(helperName)) {
         return;
       }
 
       if (node.params.length === 1) {
         if (node.params[0].type !== 'StringLiteral') {
           this.log({
-            message:
-              'You cannot pass dynamic values to scoped-class helper. {{scoped-class "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+            message: `You cannot pass dynamic values to ${helperName} helper. {{${helperName} "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md`,
             node,
           });
         }
       } else {
         this.log({
-          message:
-            'One positional param is required to be passed to scoped-class helper. {{scoped-class "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          message: `One positional param is required to be passed to ${helperName} helper. {{${helperName} "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md`,
           node,
         });
       }
@@ -53,7 +60,13 @@ if (import.meta.vitest) {
     testMethod: it,
     plugins: [scopedClassHelperPlugin],
     config: true,
-    good: ['{{scoped-class "test"}}', '{{(scoped-class "test")}}'],
+    good: [
+      '{{scoped-class "test"}}',
+      '{{(scoped-class "test")}}',
+      '{{scopedClass "test"}}',
+      '{{(scopedClass "test")}}',
+      '{{some-other-helper this.someClass}}',
+    ],
     bad: [
       {
         template: '{{scoped-class}}',
@@ -74,6 +87,61 @@ if (import.meta.vitest) {
           assert.equal(
             results[0].message,
             'You cannot pass dynamic values to scoped-class helper. {{scoped-class "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          );
+        },
+      },
+      {
+        template: '{{scopedClass}}',
+
+        verifyResults(results) {
+          assert.equal(results.length, 1);
+          assert.equal(
+            results[0].message,
+            'One positional param is required to be passed to scopedClass helper. {{scopedClass "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          );
+        },
+      },
+      {
+        template: '{{scopedClass this.someClass}}',
+
+        verifyResults(results) {
+          assert.equal(results.length, 1);
+          assert.equal(
+            results[0].message,
+            'You cannot pass dynamic values to scopedClass helper. {{scopedClass "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          );
+        },
+      },
+      {
+        template: '{{scopedClass "first" "second"}}',
+
+        verifyResults(results) {
+          assert.equal(results.length, 1);
+          assert.equal(
+            results[0].message,
+            'One positional param is required to be passed to scopedClass helper. {{scopedClass "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          );
+        },
+      },
+      {
+        template: '<Foo @class={{scopedClass this.someClass}} />',
+
+        verifyResults(results) {
+          assert.equal(results.length, 1);
+          assert.equal(
+            results[0].message,
+            'You cannot pass dynamic values to scopedClass helper. {{scopedClass "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
+          );
+        },
+      },
+      {
+        template: '<Foo @class={{if x (scopedClass this.someClass)}} />',
+
+        verifyResults(results) {
+          assert.equal(results.length, 1);
+          assert.equal(
+            results[0].message,
+            'You cannot pass dynamic values to scopedClass helper. {{scopedClass "some-class"}}. More info: https://github.com/soxhub/ember-scoped-css/blob/main/docs/lint-rules.md',
           );
         },
       },


### PR DESCRIPTION
## Problem

`ScopedClassHelperRule` early-returned unless the helper was spelled `scoped-class` — the legacy hbs global:

```js
if (node.path.original !== 'scoped-class') {
  return;
}
```

Consumers import `scopedClass`. In soxhub/auditboard-frontend there are **3** uses of `scoped-class` against **519** of `scopedClass`, so the rule currently protects essentially nothing in any modern consumer — while still being enabled at `"error"` and therefore looking like it does.

This is a matching bug rather than a scope change: the addon README already describes the rule as intended "to help you prevent improper use of the `scopedClass` helper".

## Fix

Match both spellings. Both compile through the same build-time rewrite (`rewriteHbs.js` already treats `scoped-class` and `scopedClass` as equivalent), so both are subject to the same two checks. The existing checks — dynamic argument, and wrong arity — are unchanged.

The helper name is interpolated into the messages, which leaves the `scoped-class` message text **byte-identical** while producing a natural message for `scopedClass`:

```
You cannot pass dynamic values to scopedClass helper. {{scopedClass "some-class"}}. More info: …
One positional param is required to be passed to scopedClass helper. {{scopedClass "some-class"}}. More info: …
```

`docs/lint-rules.md` is updated to document both spellings.

## Testing

- `generateRuleTests` extended to cover both spellings: `good` gains `{{scopedClass "test"}}` and `{{(scopedClass "test")}}`; `bad` gains the zero-param, dynamic-argument, and two-param `scopedClass` forms, plus an attribute-position case and a nested-subexpression case.
- The existing `scoped-class` assertions are kept verbatim, which is what pins the legacy message text as unchanged.
- Added a `good` case for an unrelated helper (`{{some-other-helper this.someClass}}`) to guard against over-matching.
- With `HELPER_NAMES` temporarily narrowed back to `scoped-class` only, exactly the 5 new `scopedClass` cases fail and the legacy and unrelated-helper cases still pass.
- Full addon suite green (140 tests). `pnpm lint` green.

**No test-app in this repo enables this rule**, so the in-source rule tests are the only automated coverage. To avoid relying on that alone, the rule was also run out-of-band with a throwaway config against `test-apps/vite-app-with-compat`'s real templates — which use `{{scopedClass "…"}}`, `{{scoped-class "…"}}` *and* the `(scopedClass "…")` subexpression form:

- **zero** errors on that corpus, i.e. no false positives on valid usage;
- all three violation shapes correctly flagged when deliberately introduced.

That second check matters because this PR newly turns on matching for 519 call sites in the main consumer — the useful evidence is what it *doesn't* flag.

## Relationship to soxhub/auditboard-frontend#41310

That PR adds an ESLint rule (`auditboard/no-unrewritable-scoped-class`) covering these gaps from the consumer side, and remains necessary for the JS-computed case. This PR closes the template-side gap for the imported spelling.

Note that enabling matching on `scopedClass` will surface **pre-existing** violations in consumers that were previously unreported. Those are real — a dynamic argument genuinely cannot be rewritten at build time — but expect the rule to start failing where it had been silent.

<details>
<summary>🤖 Claude interactions</summary>

**Goal given to Claude:** Fix three independent defects in this fork as separate PRs (different risk profiles), each with a changeset. This is PR 3 of 3. The brief supplied the `3` vs `519` usage counts from soxhub/auditboard-frontend as the motivation, and asked Claude to match the imported `scopedClass` form as well as the legacy global, keep the existing two checks, and add tests for both spellings.

**Explicit instructions:** don't change public API or option names; verify against the repo's own test suite and test-apps rather than by inspection.

**Notable findings and decisions:**

- Chose to **interpolate the helper name** into the messages rather than add a second message pair. This keeps the legacy `scoped-class` text byte-identical — the existing assertions pass unmodified, which is stronger evidence of no regression than rewriting them would be.
- Found supporting evidence in `ember-scoped-css/README.md` that the rule was always *intended* to cover `scopedClass` ("prevent improper use of the `scopedClass` helper"), confirming this is a matching bug rather than a widening of scope. Cited in the PR body.
- **Discovered no test-app enables this rule**, so the repo's own lint runs never exercise it and a passing CI would have been meaningless here. Rather than stop at the unit tests, ran `ember-template-lint` out-of-band with a throwaway config over real app templates to check for false positives — `vite-app-with-compat` happens to contain all three call shapes including the subexpression form. Verified zero false positives, then verified real violations are caught. Temporary config and fixture were removed; nothing extra is committed.
- Deliberately did **not** add a `.template-lintrc` + bad fixture to a test-app, since that would have to fail lint to prove anything and would break CI.
- Left the `github.com/soxhub/...` docs URL in the messages alone despite the repo having moved to the `auditboard` org — changing it would alter existing message text and is out of scope for this PR.
- Noted in the PR body that this will surface pre-existing violations in consumers, since a rule that starts firing on 519 call sites is the reviewer's main risk here.
- **There is no changeset mechanism in this repo** — no `.changeset/`, no `@changesets/cli`, zero references to `changeset`. `release-plan` derives the changelog from PR labels + titles (RELEASE.md). Flagged back to the requester rather than writing changeset files the tooling would ignore; this PR is labelled `bug` with a user-facing title instead.
- A `pr-readiness` comment-hygiene pass was run before opening: 0 deleted, 0 rewritten. The single added comment (on `HELPER_NAMES`) was kept because the constant's two values otherwise look like one might be a typo or deletable cruft.

</details>